### PR TITLE
Add option in subplot to adjust y labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ Version 0.2.0
 
 * ``utils.chem_formula.transform_str_to_dict`` supports now recurring elements and nested brackets (`PR #13 <https://github.com/aim2dat/aim2dat/pull/13>`_).
 
+**Enhancement**
+
+* ``plots.base_plot`` added new property `subplot_align_ylabels` to adjust y labels in subplots for backend `matplotlib`.
+
 
 Version 0.1.0
 =============

--- a/aim2dat/plots/base_plot.py
+++ b/aim2dat/plots/base_plot.py
@@ -175,6 +175,7 @@ class _BasePlot(abc.ABC):
         self._subplot_share_legend = False
         self._subplot_share_colorbar = False
         self._subplot_adjust = {}
+        self._subplot_align_ylabels = False
         self._subplot_tight_layout = False
         self._subplot_gridspec_values = None
         self._subplot_gf_x = 1
@@ -679,6 +680,15 @@ class _BasePlot(abc.ABC):
     @subplot_tight_layout.setter
     def subplot_tight_layout(self, value):
         self._subplot_tight_layout = value
+
+    @property
+    def subplot_align_ylabels(self):
+        """bool: Align y label of plot. The default value is ``False``."""
+        return self._subplot_align_ylabels
+
+    @subplot_align_ylabels.setter
+    def subplot_align_ylabels(self, value):
+        self._subplot_align_ylabels = value
 
     def auto_set_axis_properties(self, set_x_label=True, set_y_label=True):
         """

--- a/aim2dat/plots/matplotlib_backend.py
+++ b/aim2dat/plots/matplotlib_backend.py
@@ -90,6 +90,8 @@ def _set_subplot_parameters(obj):
     obj._figure.subplots_adjust(**adjust_kwargs)
     if obj.subplot_tight_layout:
         obj._figure.tight_layout()
+    if obj.subplot_align_ylabels:
+        obj._figure.align_ylabels()
 
 
 def _plot2d(

--- a/doc/source/plots-properties_and_functions.ipynb
+++ b/doc/source/plots-properties_and_functions.ipynb
@@ -310,7 +310,9 @@
     "           * - :attr:`subplot_sharey <aim2dat.plots.SimplePlot.subplot_sharey>`\n",
     "             - Share the y-axis of subplots located in the same row.\n",
     "           * - :attr:`subplot_tight_layout <aim2dat.plots.SimplePlot.subplot_tight_layout>`\n",
-    "             - Whether to use tight layout of the plot."
+    "             - Whether to use tight layout of the plot.\n",
+    "           * - :attr:`subplot_align_ylabels <aim2dat.plots.SimplePlot.subplot_align_ylabels>`\n",
+    "             - Whether to align the y labels of the subplots."
    ]
   }
  ],
@@ -331,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For plotting for example partial charges, the y label usually is not aligned since the y range varies for each species. Matplotlib has a function for this, and I added the property `subplot_align_ylabels` to the `_Baseplot` class to call the function.
