### PR TITLE
List of `Structure` objects as input to `StructureOperations`

### DIFF
--- a/aim2dat/strct/structure_collection.py
+++ b/aim2dat/strct/structure_collection.py
@@ -41,7 +41,7 @@ class StructureCollection:
         List of ``Structure`` or dict objects.
     """
 
-    def __init__(self, structures: Union[list, None] = None):
+    def __init__(self, structures: Union[List[Union[Structure, dict]], None] = None):
         """Initialize object."""
         self._structures = []
         if structures is not None:

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -75,7 +75,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
 
     def __init__(
         self,
-        structures: StructureCollection,
+        structures: Union[List[Union[Structure, dict]], StructureCollection],
         append_to_coll: bool = True,
         output_format: str = "dict",
         n_procs: int = 1,
@@ -148,11 +148,13 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         return self._structures
 
     @structures.setter
-    def structures(self, value: StructureCollection):
+    def structures(self, value: Union[List[Union[Structure, dict]], StructureCollection]):
         if isinstance(value, StructureCollection):
             self._structures = value
+        elif isinstance(value, list):
+            self._structures = StructureCollection(value)
         else:
-            raise TypeError("`structures` needs to be of type `StructureCollection`.")
+            raise TypeError("`structures` needs to be of type `StructureCollection` or `list`.")
 
     @property
     def verbose(self) -> bool:

--- a/tests/strct/test_structure_op.py
+++ b/tests/strct/test_structure_op.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 # Internal library imports
-from aim2dat.strct import StructureOperations, StructureCollection
+from aim2dat.strct import StructureOperations, StructureCollection, Structure
 from aim2dat.io.yaml import load_yaml_file
 
 STRUCTURES_PATH = os.path.dirname(__file__) + "/structures/"
@@ -21,6 +21,12 @@ def test_structure_ops_basics():
     strct_collect.append("Cs2Te_62_prim", **inputs)
 
     strct_ops = StructureOperations(structures=strct_collect, append_to_coll=True)
+
+    strct_ops_inp_list = StructureOperations([Structure(label="Cs2Te_62_prim", **inputs)])
+    assert isinstance(strct_ops_inp_list.structures, StructureCollection)
+
+    with pytest.raises(TypeError) as error:
+        StructureOperations([1, 2, 3])
 
     with pytest.raises(TypeError) as error:
         strct_ops.append_to_coll = "test"


### PR DESCRIPTION
Fixes #17 

The `StructureOperations` class takes only a `StructureCollection` as an input at the moment. Here we allow the user to pass a list of `Structure` objects to initialize `StructureOperations`.

@hdsassnick `StructureCollection` also accepts a list of dictionaries. I only added support for a list of `Structure`s to initialize `StructureOperations`, as this is somehow the main object to represent a structure. In case you prefer to also allow a list of dictionaries, I will add this as well. 