### PR TITLE
Voronoi analysis - fixed order

### DIFF
--- a/aim2dat/strct/strct_super_cell.py
+++ b/aim2dat/strct/strct_super_cell.py
@@ -49,7 +49,12 @@ def calculate_voronoi_tessellation(
                         "vertices": [vor_scipy.vertices[idx] + shift for idx in ridge_v],
                     }
                 )
-        voronoi_list.append(neighbours)
+        voronoi_list.append(
+            sorted(
+                neighbours,
+                key=lambda neighbor: (neighbor["index"], *neighbor["position"].tolist()),
+            )
+        )
     return None, voronoi_list
 
 

--- a/tests/strct/coordination/Cs2Te_62_prim_okeeffe.yaml
+++ b/tests/strct/coordination/Cs2Te_62_prim_okeeffe.yaml
@@ -12,30 +12,6 @@ ref:
     max_dist: 4.477765890306448
     avg_dist: 4.1301649678517425
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 1.472817, -1.3017499039999998]
-      weight: 0.9893189059368018
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.864835681657127
-      position: [7.190669586000001, 4.418451, 1.301749904]
-      weight: 0.9121276148851952
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.477765890306448
-      position: [5.013415050000002, 7.364085, 3.789022042]
-      weight: 0.5407177013285455
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 7.364085, -1.3017499039999998]
-      weight: 0.9893189059368024
     - element: Cs
       kind:
       site_index: 1
@@ -44,22 +20,46 @@ ref:
       weight: 0.5727654469117527
     - element: Cs
       kind:
+      site_index: 1
+      distance: 4.440793142957318
+      position: [0.2406439224000009, 7.364085, 2.022361458]
+      weight: 0.5727654469117525
+    - element: Cs
+      kind:
       site_index: 2
       distance: 4.477765890306448
       position: [5.013415050000002, 1.472817, 3.789022042]
       weight: 0.5407177013285454
+    - element: Cs
+      kind:
+      site_index: 2
+      distance: 4.477765890306448
+      position: [5.013415050000002, 7.364085, 3.789022042]
+      weight: 0.5407177013285455
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.864835681657127
+      position: [7.190669586000001, 4.418451, 1.301749904]
+      weight: 0.9121276148851952
     - element: Te
       kind:
       site_index: 9
       distance: 3.773254580651904
       position: [2.415988586000001, 4.418451, 4.509633596]
       weight: 1.0
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 1
-      distance: 4.440793142957318
-      position: [0.2406439224000009, 7.364085, 2.022361458]
-      weight: 0.5727654469117525
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 1.472817, -1.3017499039999998]
+      weight: 0.9893189059368018
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 7.364085, -1.3017499039999998]
+      weight: 0.9893189059368024
   - Cs: 4
     Te: 5
     element: Cs
@@ -70,30 +70,36 @@ ref:
     max_dist: 4.4822853026157565
     avg_dist: 4.292132135283276
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9415537240720857
-      position: [2.358692414, 1.472817, -1.3017499039999998]
-      weight: 0.9900857371049084
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.440793142957318
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-      weight: 0.6255203583062685
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, -1.472817, 1.301749904]
-      weight: 1.0
     - element: Cs
       kind:
       site_index: 0
       distance: 4.440793142957318
       position: [3.3518260619999998, -1.472817, 0.8542733745]
       weight: 0.6255203583062683
+    - element: Cs
+      kind:
+      site_index: 0
+      distance: 4.440793142957318
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      weight: 0.6255203583062685
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.4822853026157565
+      position: [-1.4228549380000002, -1.472817, 4.962921509]
+      weight: 0.5885826859164495
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.4822853026157565
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+      weight: 0.5885826859164495
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, -1.472817, 1.301749904]
+      weight: 1.0
     - element: Te
       kind:
       site_index: 8
@@ -106,24 +112,18 @@ ref:
       distance: 4.426669939794483
       position: [2.415988586, -1.472817, 4.509633596]
       weight: 0.6353885636073194
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.4822853026157565
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-      weight: 0.5885826859164495
     - element: Te
       kind:
       site_index: 9
       distance: 4.426669939794483
       position: [2.415988586, 4.418451, 4.509633596]
       weight: 0.6353885636073192
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 3
-      distance: 4.4822853026157565
-      position: [-1.4228549380000002, -1.472817, 4.962921509]
-      weight: 0.5885826859164495
+      site_index: 11
+      distance: 3.9415537240720857
+      position: [2.358692414, 1.472817, -1.3017499039999998]
+      weight: 0.9900857371049084
   - Cs: 4
     Te: 5
     element: Cs
@@ -134,12 +134,12 @@ ref:
     max_dist: 4.477765890306448
     avg_dist: 4.291812136918563
     neighbours:
-    - element: Te
+    - element: Cs
       kind:
-      site_index: 8
-      distance: 4.427608797642319
-      position: [7.190669586, 4.418451, 1.301749904]
-      weight: 0.6355907654450212
+      site_index: 0
+      distance: 4.477765890306448
+      position: [3.3518260619999998, -1.472817, 0.8542733745]
+      weight: 0.5907603233880239
     - element: Cs
       kind:
       site_index: 0
@@ -150,26 +150,14 @@ ref:
       kind:
       site_index: 3
       distance: 4.443663071808785
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 0.6244140656569724
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.477765890306448
-      position: [3.3518260619999998, -1.472817, 0.8542733745]
-      weight: 0.5907603233880239
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: 0.9999999999999994
+      position: [8.126507062, -1.472817, 4.962921509]
+      weight: 0.6244140656569722
     - element: Cs
       kind:
       site_index: 3
       distance: 4.443663071808785
-      position: [8.126507062, -1.472817, 4.962921509]
-      weight: 0.6244140656569722
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 0.6244140656569724
     - element: Te
       kind:
       site_index: 8
@@ -178,10 +166,22 @@ ref:
       weight: 0.6355907654450212
     - element: Te
       kind:
+      site_index: 8
+      distance: 4.427608797642319
+      position: [7.190669586, 4.418451, 1.301749904]
+      weight: 0.6355907654450212
+    - element: Te
+      kind:
       site_index: 9
       distance: 3.9928266816381903
       position: [2.415988586, -1.472817, 4.509633596]
       weight: 1.0
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: 0.9999999999999994
     - element: Te
       kind:
       site_index: 10
@@ -198,18 +198,6 @@ ref:
     max_dist: 4.482285302615756
     avg_dist: 4.131973462891795
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.778884663858415
-      position: [7.190669586, 4.418451, 1.301749904]
-      weight: 1.0
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.443663071808785
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 0.5728619412534998
     - element: Cs
       kind:
       site_index: 1
@@ -226,14 +214,20 @@ ref:
       kind:
       site_index: 2
       distance: 4.443663071808785
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 0.5728619412534998
+    - element: Cs
+      kind:
+      site_index: 2
+      distance: 4.443663071808785
       position: [5.013415050000001, 7.364085, 3.789022042]
       weight: 0.5728619412534999
     - element: Te
       kind:
-      site_index: 10
-      distance: 3.779746724073622
-      position: [7.133373414, 7.364085, 7.113133404]
-      weight: 0.9934348820247334
+      site_index: 8
+      distance: 3.778884663858415
+      position: [7.190669586, 4.418451, 1.301749904]
+      weight: 1.0
     - element: Te
       kind:
       site_index: 9
@@ -246,6 +240,12 @@ ref:
       distance: 3.779746724073622
       position: [7.133373414, 1.472817, 7.113133404]
       weight: 0.9934348820247337
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.779746724073622
+      position: [7.133373414, 7.364085, 7.113133404]
+      weight: 0.9934348820247334
   - Cs: 4
     Te: 4
     element: Cs
@@ -256,18 +256,6 @@ ref:
     max_dist: 4.4815768475544395
     avg_dist: 4.131796349126466
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.865512842279616
-      position: [-2.415988586, 1.472817, 7.113133404]
-      weight: 0.9140185059470967
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.5729235954815357
     - element: Cs
       kind:
       site_index: 5
@@ -276,16 +264,16 @@ ref:
       weight: 0.5729235954815358
     - element: Cs
       kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.5729235954815357
+    - element: Cs
+      kind:
       site_index: 6
       distance: 4.4815768475544395
       position: [-0.23873405000000023, -1.472817, 9.600405541999999]
       weight: 0.5406152165511824
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, -1.472817, 4.509633596]
-      weight: 0.9936018000848914
     - element: Cs
       kind:
       site_index: 6
@@ -296,8 +284,20 @@ ref:
       kind:
       site_index: 9
       distance: 3.779746724073622
+      position: [2.415988586, -1.472817, 4.509633596]
+      weight: 0.9936018000848914
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
       position: [2.415988586, 4.418451, 4.509633596]
       weight: 0.9936018000848911
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.865512842279616
+      position: [-2.415988586, 1.472817, 7.113133404]
+      weight: 0.9140185059470967
     - element: Te
       kind:
       site_index: 11
@@ -316,22 +316,28 @@ ref:
     neighbours:
     - element: Cs
       kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 0.6236994105977773
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 7.364085, 6.659845491]
+      weight: 0.623699410597777
+    - element: Cs
+      kind:
       site_index: 7
       distance: 4.48157684755444
       position: [6.197535938000001, 1.472817, 10.774305009]
       weight: 0.5888962793184328
     - element: Cs
       kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 0.6236994105977773
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 0.6360225062084774
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 7.364085, 10.774305009]
+      weight: 0.5888962793184329
     - element: Te
       kind:
       site_index: 9
@@ -346,28 +352,22 @@ ref:
       weight: 1.0
     - element: Te
       kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 7.364085, 10.321017096]
-      weight: 0.6360225062084774
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 7.364085, 10.774305009]
-      weight: 0.5888962793184329
-    - element: Te
-      kind:
       site_index: 10
       distance: 3.9928266816381903
       position: [7.133373414, 7.364085, 7.113133404]
       weight: 1.0
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 7.364085, 6.659845491]
-      weight: 0.623699410597777
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 0.6360225062084774
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 7.364085, 10.321017096]
+      weight: 0.6360225062084774
   - Cs: 4
     Te: 5
     element: Cs
@@ -380,34 +380,28 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 1.472817, 10.774305009000003]
-      weight: 0.623352367997393
+      site_index: 4
+      distance: 4.4815768475544395
+      position: [10.972216938, 1.472817, 6.659845491000001]
+      weight: 0.58816801750794
     - element: Cs
       kind:
       site_index: 4
       distance: 4.4815768475544395
       position: [10.972216938, 7.364085, 6.659845491000001]
       weight: 0.5881680175079399
-    - element: Te
+    - element: Cs
       kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 7.364085, 10.321017096000002]
-      weight: 0.9999999999999999
-    - element: Te
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 1.472817, 10.774305009000003]
+      weight: 0.623352367997393
+    - element: Cs
       kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 1.472817, 10.321017096000002]
-      weight: 1.0
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 4.427608797642319
-      position: [7.133373414, 7.364085, 7.113133404000002]
-      weight: 0.6349395133555108
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 7.364085, 10.774305009000003]
+      weight: 0.6233523679973928
     - element: Te
       kind:
       site_index: 8
@@ -420,18 +414,24 @@ ref:
       distance: 4.427608797642319
       position: [7.133373414, 1.472817, 7.113133404000002]
       weight: 0.6349395133555108
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 7.364085, 10.774305009000003]
-      weight: 0.6233523679973928
-    - element: Cs
+      site_index: 10
+      distance: 4.427608797642319
+      position: [7.133373414, 7.364085, 7.113133404000002]
+      weight: 0.6349395133555108
+    - element: Te
       kind:
-      site_index: 4
-      distance: 4.4815768475544395
-      position: [10.972216938, 1.472817, 6.659845491000001]
-      weight: 0.58816801750794
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 1.472817, 10.321017096000002]
+      weight: 1.0
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 7.364085, 10.321017096000002]
+      weight: 0.9999999999999999
   - Cs: 4
     Te: 4
     element: Cs
@@ -442,42 +442,18 @@ ref:
     max_dist: 4.48157684755444
     avg_dist: 4.131796349126466
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.778884663858416
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: 1.0
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.5409538120124976
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.8655128422796166
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 0.9148164720636685
     - element: Cs
       kind:
       site_index: 5
       distance: 4.48157684755444
       position: [4.53594695, -1.472817, 7.8337449580000005]
       weight: 0.5409538120124978
-    - element: Te
+    - element: Cs
       kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, -1.472817, 12.924516904]
-      weight: 0.9941023577482146
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, 4.418451, 12.924516904]
-      weight: 0.9941023577482141
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.5409538120124976
     - element: Cs
       kind:
       site_index: 6
@@ -490,6 +466,30 @@ ref:
       distance: 4.443663071808786
       position: [9.31062795, 4.418451, 9.600405541999999]
       weight: 0.5729549471942411
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, -1.472817, 12.924516904]
+      weight: 0.9941023577482146
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, 4.418451, 12.924516904]
+      weight: 0.9941023577482141
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.778884663858416
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: 1.0
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.8655128422796166
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 0.9148164720636685
   - Cs: 9
     Te: 0
     element: Te
@@ -502,10 +502,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 1
-      distance: 3.9940693613711393
-      position: [9.790005922399999, 7.364085, 2.022361458]
-      weight: 0.9178112713916924
+      site_index: 0
+      distance: 3.864835681657127
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      weight: 0.9142682317646227
     - element: Cs
       kind:
       site_index: 1
@@ -514,16 +514,16 @@ ref:
       weight: 0.9178112713916926
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9425803494755884
-      position: [9.31062795, 4.418451, -2.0223614580000002]
-      weight: 0.90833313647544
+      site_index: 1
+      distance: 3.9940693613711393
+      position: [9.790005922399999, 7.364085, 2.022361458]
+      weight: 0.9178112713916924
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.7797467240736218
-      position: [6.197535938000001, 7.364085, -0.8484619909999994]
-      weight: 0.9938373908855785
+      site_index: 2
+      distance: 4.427608797642319
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 0.58311588377264
     - element: Cs
       kind:
       site_index: 2
@@ -538,10 +538,10 @@ ref:
       weight: 1.0
     - element: Cs
       kind:
-      site_index: 2
-      distance: 4.427608797642319
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 0.58311588377264
+      site_index: 6
+      distance: 3.9425803494755884
+      position: [9.31062795, 4.418451, -2.0223614580000002]
+      weight: 0.90833313647544
     - element: Cs
       kind:
       site_index: 7
@@ -550,10 +550,10 @@ ref:
       weight: 0.9938373908855785
     - element: Cs
       kind:
-      site_index: 0
-      distance: 3.864835681657127
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-      weight: 0.9142682317646227
+      site_index: 7
+      distance: 3.7797467240736218
+      position: [6.197535938000001, 7.364085, -0.8484619909999994]
+      weight: 0.9938373908855785
   - Cs: 9
     Te: 0
     element: Te
@@ -572,12 +572,6 @@ ref:
       weight: 1.0
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.779746724073622
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 0.9910112226147818
-    - element: Cs
-      kind:
       site_index: 1
       distance: 4.426669939794483
       position: [0.24064392240000002, 1.472817, 2.022361458]
@@ -588,12 +582,6 @@ ref:
       distance: 4.426669939794483
       position: [0.24064392240000002, 7.364085, 2.022361458]
       weight: 0.5818013910571638
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 3.942580349475589
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.9061279256406598
     - element: Cs
       kind:
       site_index: 2
@@ -616,8 +604,20 @@ ref:
       kind:
       site_index: 4
       distance: 3.779746724073622
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 0.9910112226147818
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.779746724073622
       position: [1.422854938, 7.364085, 6.659845491]
       weight: 0.9910112226147814
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.942580349475589
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.9061279256406598
   - Cs: 9
     Te: 0
     element: Te
@@ -630,22 +630,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 3.779746724073622
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 0.9936997415745306
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 3.778884663858416
-      position: [6.197535938000001, 1.472817, 10.774305009]
-      weight: 1.0
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.427608797642319
-      position: [9.31062795, 4.418451, 9.600405541999999]
-      weight: 0.583605283340586
+      site_index: 2
+      distance: 3.942580349475588
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 0.9085032934411579
     - element: Cs
       kind:
       site_index: 3
@@ -654,10 +642,16 @@ ref:
       weight: 0.9936997415745309
     - element: Cs
       kind:
-      site_index: 2
-      distance: 3.942580349475588
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 0.9085032934411579
+      site_index: 3
+      distance: 3.779746724073622
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 0.9936997415745306
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.8655128422796166
+      position: [10.972216938, 1.472817, 6.659845491]
+      weight: 0.9140185059470963
     - element: Cs
       kind:
       site_index: 5
@@ -666,22 +660,28 @@ ref:
       weight: 0.9185892847524485
     - element: Cs
       kind:
-      site_index: 6
-      distance: 4.427608797642319
-      position: [9.31062795, -1.472817, 9.600405541999999]
-      weight: 0.583605283340586
-    - element: Cs
-      kind:
       site_index: 5
       distance: 3.9928266816381903
       position: [4.53594695, 4.418451, 7.8337449580000005]
       weight: 0.9185892847524488
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.8655128422796166
-      position: [10.972216938, 1.472817, 6.659845491]
-      weight: 0.9140185059470963
+      site_index: 6
+      distance: 4.427608797642319
+      position: [9.31062795, -1.472817, 9.600405541999999]
+      weight: 0.583605283340586
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.427608797642319
+      position: [9.31062795, 4.418451, 9.600405541999999]
+      weight: 0.583605283340586
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 3.778884663858416
+      position: [6.197535938000001, 1.472817, 10.774305009]
+      weight: 1.0
   - Cs: 9
     Te: 0
     element: Te
@@ -694,34 +694,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.865512842279617
-      position: [6.1975359380000015, 1.472817, 10.774305009]
-      weight: 0.9148164720636683
-    - element: Cs
-      kind:
       site_index: 0
       distance: 3.783055706988686
       position: [3.351826062, -1.472817, 12.477040374499998]
       weight: 0.9919050595645195
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 3.778884663858416
-      position: [1.4228549380000004, 1.472817, 6.659845491]
-      weight: 1.0
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
-      weight: 0.9191509916533059
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.427608797642319
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.5842434590645054
     - element: Cs
       kind:
       site_index: 0
@@ -730,72 +706,96 @@ ref:
       weight: 0.9919050595645201
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
-      weight: 0.9191509916533058
-    - element: Cs
-      kind:
       site_index: 1
       distance: 3.9415537240720844
       position: [0.24064392240000046, 1.472817, 13.645128457999999]
       weight: 0.9089541207116267
     - element: Cs
       kind:
+      site_index: 4
+      distance: 3.778884663858416
+      position: [1.4228549380000004, 1.472817, 6.659845491]
+      weight: 1.0
+    - element: Cs
+      kind:
       site_index: 5
       distance: 4.427608797642319
       position: [4.53594695, -1.472817, 7.8337449580000005]
       weight: 0.5842434590645057
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.427608797642319
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.5842434590645054
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
+      weight: 0.9191509916533059
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
+      weight: 0.9191509916533058
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 3.865512842279617
+      position: [6.1975359380000015, 1.472817, 10.774305009]
+      weight: 0.9148164720636683
   nrs_avg:
-    &id001 [Cs, Cs]: 4
-    &id002 [Cs, Te]: 4.5
-    &id003 [Te, Cs]: 9
-    &id004 [Te, Te]: 0
+    [Cs, Cs]: 4
+    [Cs, Te]: 4.5
+    [Te, Cs]: 9
+    [Te, Te]: 0
   nrs_stdev:
-    *id001 : 0.0
-    *id002 : 0.5345224838248488
-    *id003 : 0.0
-    *id004 : 0.0
+    [Cs, Cs]: 0.0
+    [Cs, Te]: 0.5345224838248488
+    [Te, Cs]: 0.0
+    [Te, Te]: 0.0
   nrs_max:
-    *id001 : 4
-    *id002 : 5
-    *id003 : 9
-    *id004 : 0
+    [Cs, Cs]: 4
+    [Cs, Te]: 5
+    [Te, Cs]: 9
+    [Te, Te]: 0
   nrs_min:
-    *id001 : 4
-    *id002 : 4
-    *id003 : 9
-    *id004 : 0
+    [Cs, Cs]: 4
+    [Cs, Te]: 4
+    [Te, Cs]: 9
+    [Te, Te]: 0
   distance_avg:
-    &id005 [Cs, Te]: 3.9985905774904276
-    &id006 [Cs, Cs]: 4.461873405801845
-    &id007 [Te, Cs]: 3.998590577490427
+    [Cs, Te]: 3.9985905774904276
+    [Cs, Cs]: 4.461873405801845
+    [Te, Cs]: 3.998590577490427
   distance_stdev:
-    *id005 : 0.24672846215561214
-    *id006 : 0.01929363626683861
-    *id007 : 0.24672846215561223
+    [Cs, Te]: 0.24672846215561214
+    [Cs, Cs]: 0.01929363626683861
+    [Te, Cs]: 0.24672846215561223
   distance_max:
-    *id005 : 4.4276087976423195
-    *id006 : 4.4822853026157565
-    *id007 : 4.4276087976423195
+    [Cs, Te]: 4.4276087976423195
+    [Cs, Cs]: 4.4822853026157565
+    [Te, Cs]: 4.4276087976423195
   distance_min:
-    *id005 : 3.7732545806519044
-    *id006 : 4.440793142957319
-    *id007 : 3.7732545806519044
+    [Cs, Te]: 3.7732545806519044
+    [Cs, Cs]: 4.440793142957319
+    [Te, Cs]: 3.7732545806519044
   weight_avg:
-    *id005 : 0.9065860988016973
-    *id006 : 0.5817121245439142
-    *id007 : 0.8676321185430881
+    [Cs, Te]: 0.9065860988016973
+    [Cs, Cs]: 0.5817121245439142
+    [Te, Cs]: 0.8676321185430881
   weight_stdev:
-    *id005 : 0.1492413277933769
-    *id006 : 0.030614634033087458
-    *id007 : 0.15833066424347023
+    [Cs, Te]: 0.1492413277933769
+    [Cs, Cs]: 0.030614634033087458
+    [Te, Cs]: 0.15833066424347023
   weight_max:
-    *id005 : 1.0
-    *id006 : 0.6255203583062681
-    *id007 : 1.0
+    [Cs, Te]: 1.0
+    [Cs, Cs]: 0.6255203583062681
+    [Te, Cs]: 1.0
   weight_min:
-    *id005 : 0.6349395133555118
-    *id006 : 0.5402078232801137
-    *id007 : 0.581801391057164
+    [Cs, Te]: 0.6349395133555118
+    [Cs, Cs]: 0.5402078232801137
+    [Te, Cs]: 0.581801391057164
 parameters: {r_max: 5.0, method: okeeffe, okeeffe_weight_threshold: 0.5}

--- a/tests/strct/coordination/Cs2Te_62_prim_voronoi_area.yaml
+++ b/tests/strct/coordination/Cs2Te_62_prim_voronoi_area.yaml
@@ -12,47 +12,17 @@ ref:
     max_dist: 4.79190302513394
     avg_dist: 4.275425519939675
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 1.472817, -1.3017499039999998]
-      weight: 9.083184602198685
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.864835681657127
-      position: [7.190669586000001, 4.418451, 1.301749904]
-      weight: 8.379713700118263
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.477765890306448
-      position: [5.013415050000002, 7.364085, 3.789022042]
-      weight: 5.69046969552847
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 7.364085, -1.3017499039999998]
-      weight: 9.083184602198687
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
-      weight: 4.578167209777735
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.600777094952304
-      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
-      weight: 4.459908669736876
     - element: Cs
       kind:
       site_index: 1
       distance: 4.440793142957318
       position: [0.2406439224000009, 1.472817, 2.022361458]
+      weight: 6.0799620791083715
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 4.440793142957318
+      position: [0.2406439224000009, 7.364085, 2.022361458]
       weight: 6.0799620791083715
     - element: Cs
       kind:
@@ -62,28 +32,58 @@ ref:
       weight: 5.690469695528469
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
-      weight: 4.578167209777735
+      site_index: 2
+      distance: 4.477765890306448
+      position: [5.013415050000002, 7.364085, 3.789022042]
+      weight: 5.69046969552847
     - element: Cs
       kind:
       site_index: 5
       distance: 4.79190302513394
       position: [4.5359469500000005, 4.418451, -3.7890220419999996]
       weight: 3.974322538073712
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.600777094952304
+      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
+      weight: 4.459908669736876
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
+      weight: 4.578167209777735
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
+      weight: 4.578167209777735
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.864835681657127
+      position: [7.190669586000001, 4.418451, 1.301749904]
+      weight: 8.379713700118263
     - element: Te
       kind:
       site_index: 9
       distance: 3.773254580651904
       position: [2.415988586000001, 4.418451, 4.509633596]
       weight: 9.136684294912694
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 1
-      distance: 4.440793142957318
-      position: [0.2406439224000009, 7.364085, 2.022361458]
-      weight: 6.0799620791083715
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 1.472817, -1.3017499039999998]
+      weight: 9.083184602198685
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 7.364085, -1.3017499039999998]
+      weight: 9.083184602198687
   - Cs: 10
     Te: 5
     element: Cs
@@ -96,16 +96,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.598637609569076
-      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
-      weight: 4.467273737659038
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9415537240720857
-      position: [2.358692414, 1.472817, -1.3017499039999998]
-      weight: 8.677363336522939
+      site_index: 0
+      distance: 4.440793142957318
+      position: [3.3518260619999998, -1.472817, 0.8542733745]
+      weight: 6.079962079108369
     - element: Cs
       kind:
       site_index: 0
@@ -114,34 +108,28 @@ ref:
       weight: 6.0799620791083715
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
-      weight: 2.30016047520391
+      site_index: 2
+      distance: 5.092829270783993
+      position: [-4.53594695, 1.472817, 3.789022042]
+      weight: 2.933606030806661
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
-      weight: 2.3001604752039118
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, -1.472817, 1.301749904]
-      weight: 9.063586664858757
+      site_index: 2
+      distance: 5.089246884904623
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 2.936720114651884
     - element: Cs
       kind:
-      site_index: 0
-      distance: 4.440793142957318
-      position: [3.3518260619999998, -1.472817, 0.8542733745]
-      weight: 6.079962079108369
-    - element: Te
+      site_index: 3
+      distance: 4.4822853026157565
+      position: [-1.4228549380000002, -1.472817, 4.962921509]
+      weight: 5.677878878445281
+    - element: Cs
       kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, 4.418451, 1.301749904]
-      weight: 9.063586664858757
+      site_index: 3
+      distance: 4.4822853026157565
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+      weight: 5.677878878445282
     - element: Cs
       kind:
       site_index: 4
@@ -150,40 +138,52 @@ ref:
       weight: 3.9927839883274414
     - element: Cs
       kind:
-      site_index: 2
-      distance: 5.089246884904623
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 2.936720114651884
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
+      weight: 2.3001604752039118
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
+      weight: 2.30016047520391
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.598637609569076
+      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
+      weight: 4.467273737659038
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, -1.472817, 1.301749904]
+      weight: 9.063586664858757
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, 4.418451, 1.301749904]
+      weight: 9.063586664858757
     - element: Te
       kind:
       site_index: 9
       distance: 4.426669939794483
       position: [2.415988586, -1.472817, 4.509633596]
       weight: 5.978058839098272
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.4822853026157565
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-      weight: 5.677878878445282
     - element: Te
       kind:
       site_index: 9
       distance: 4.426669939794483
       position: [2.415988586, 4.418451, 4.509633596]
       weight: 5.978058839098269
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 2
-      distance: 5.092829270783993
-      position: [-4.53594695, 1.472817, 3.789022042]
-      weight: 2.933606030806661
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.4822853026157565
-      position: [-1.4228549380000002, -1.472817, 4.962921509]
-      weight: 5.677878878445281
+      site_index: 11
+      distance: 3.9415537240720857
+      position: [2.358692414, 1.472817, -1.3017499039999998]
+      weight: 8.677363336522939
   - Cs: 10
     Te: 5
     element: Cs
@@ -194,24 +194,6 @@ ref:
     max_dist: 5.092829270783991
     avg_dist: 4.549637854201829
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 4.427608797642319
-      position: [7.190669586, 4.418451, 1.301749904]
-      weight: 5.9798665352215465
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.477765890306448
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-      weight: 5.690469695528469
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.443663071808785
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 6.071615739906592
     - element: Cs
       kind:
       site_index: 0
@@ -220,10 +202,34 @@ ref:
       weight: 5.690469695528469
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.78627208103842
-      position: [6.197535938000001, 1.472817, -0.8484619909999994]
-      weight: 3.9906419739036827
+      site_index: 0
+      distance: 4.477765890306448
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      weight: 5.690469695528469
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 5.089246884904623
+      position: [0.24064392240000002, 1.472817, 2.022361458]
+      weight: 2.936720114651884
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 5.092829270783991
+      position: [9.790005922399999, 1.472817, 2.022361458]
+      weight: 2.933606030806662
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.443663071808785
+      position: [8.126507062, -1.472817, 4.962921509]
+      weight: 6.0716157399065915
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.443663071808785
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 6.071615739906592
     - element: Cs
       kind:
       site_index: 4
@@ -232,40 +238,10 @@ ref:
       weight: 4.470731005636362
     - element: Cs
       kind:
-      site_index: 1
-      distance: 5.089246884904623
-      position: [0.24064392240000002, 1.472817, 2.022361458]
-      weight: 2.936720114651884
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: 9.054348099432257
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.443663071808785
-      position: [8.126507062, -1.472817, 4.962921509]
-      weight: 6.0716157399065915
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 4.427608797642319
-      position: [7.190669586, -1.472817, 1.301749904]
-      weight: 5.979866535221548
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, -1.472817, 4.509633596]
-      weight: 9.05434809943226
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.942580349475588
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: 8.675443200804002
+      site_index: 5
+      distance: 5.026382289051357
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 2.299934067060262
     - element: Cs
       kind:
       site_index: 5
@@ -274,16 +250,40 @@ ref:
       weight: 2.2999340670602617
     - element: Cs
       kind:
-      site_index: 5
-      distance: 5.026382289051357
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-      weight: 2.299934067060262
-    - element: Cs
+      site_index: 7
+      distance: 4.78627208103842
+      position: [6.197535938000001, 1.472817, -0.8484619909999994]
+      weight: 3.9906419739036827
+    - element: Te
       kind:
-      site_index: 1
-      distance: 5.092829270783991
-      position: [9.790005922399999, 1.472817, 2.022361458]
-      weight: 2.933606030806662
+      site_index: 8
+      distance: 4.427608797642319
+      position: [7.190669586, -1.472817, 1.301749904]
+      weight: 5.979866535221548
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 4.427608797642319
+      position: [7.190669586, 4.418451, 1.301749904]
+      weight: 5.9798665352215465
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, -1.472817, 4.509633596]
+      weight: 9.05434809943226
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: 9.054348099432257
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.942580349475588
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: 8.675443200804002
   - Cs: 8
     Te: 4
     element: Cs
@@ -294,18 +294,6 @@ ref:
     max_dist: 4.78627208103842
     avg_dist: 4.275488052835503
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.778884663858415
-      position: [7.190669586, 4.418451, 1.301749904]
-      weight: 9.130139861067637
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.443663071808785
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 6.071615739906592
     - element: Cs
       kind:
       site_index: 1
@@ -322,25 +310,25 @@ ref:
       kind:
       site_index: 2
       distance: 4.443663071808785
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 6.071615739906592
+    - element: Cs
+      kind:
+      site_index: 2
+      distance: 4.443663071808785
       position: [5.013415050000001, 7.364085, 3.789022042]
       weight: 6.0716157399065915
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.779746724073622
-      position: [7.133373414, 7.364085, 7.113133404]
-      weight: 9.092627235305683
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.8655128422796174
-      position: [11.965350586000001, 4.418451, 4.509633596]
-      weight: 8.3761578156865
     - element: Cs
       kind:
       site_index: 4
       distance: 4.433325541961325
       position: [10.972216938, 1.472817, 6.659845491]
+      weight: 4.584751719810797
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.433325541961325
+      position: [10.972216938, 7.364085, 6.659845491]
       weight: 4.584751719810797
     - element: Cs
       kind:
@@ -350,21 +338,33 @@ ref:
       weight: 4.471081428738642
     - element: Cs
       kind:
-      site_index: 4
-      distance: 4.433325541961325
-      position: [10.972216938, 7.364085, 6.659845491]
-      weight: 4.584751719810797
-    - element: Cs
-      kind:
       site_index: 6
       distance: 4.78627208103842
       position: [9.31062795, 4.418451, 9.600405541999999]
       weight: 3.991956381159493
     - element: Te
       kind:
+      site_index: 8
+      distance: 3.778884663858415
+      position: [7.190669586, 4.418451, 1.301749904]
+      weight: 9.130139861067637
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.8655128422796174
+      position: [11.965350586000001, 4.418451, 4.509633596]
+      weight: 8.3761578156865
+    - element: Te
+      kind:
       site_index: 10
       distance: 3.779746724073622
       position: [7.133373414, 1.472817, 7.113133404]
+      weight: 9.092627235305683
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.779746724073622
+      position: [7.133373414, 7.364085, 7.113133404]
       weight: 9.092627235305683
   - Cs: 8
     Te: 4
@@ -376,54 +376,6 @@ ref:
     max_dist: 4.785799937495917
     avg_dist: 4.275330631696741
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.865512842279616
-      position: [-2.415988586, 1.472817, 7.113133404]
-      weight: 8.376535496535926
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 6.070223600017436
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-      weight: 6.070223600017433
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
-      weight: 5.679405475498814
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, -1.472817, 4.509633596]
-      weight: 9.090981838040085
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.433325541961324
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-      weight: 4.5847517198108
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-      weight: 5.679405475498815
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: 9.090981838040085
     - element: Cs
       kind:
       site_index: 1
@@ -436,18 +388,66 @@ ref:
       distance: 4.597145765930607
       position: [5.013415050000001, 1.472817, 3.789022042]
       weight: 4.470731005636362
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.778884663858416
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 9.126633518453396
     - element: Cs
       kind:
       site_index: 3
       distance: 4.433325541961324
       position: [-1.4228549380000002, -1.472817, 4.962921509]
       weight: 4.5847517198108
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.433325541961324
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+      weight: 4.5847517198108
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 6.070223600017433
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 6.070223600017436
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
+      weight: 5.679405475498814
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+      weight: 5.679405475498815
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, -1.472817, 4.509633596]
+      weight: 9.090981838040085
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: 9.090981838040085
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.865512842279616
+      position: [-2.415988586, 1.472817, 7.113133404]
+      weight: 8.376535496535926
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.778884663858416
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 9.126633518453396
   - Cs: 10
     Te: 5
     element: Cs
@@ -460,82 +460,34 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.597145765930607
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 4.471081428738642
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 1.472817, 10.774305009]
-      weight: 5.684178177957947
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.091038034705715
-      position: [9.31062795, 4.418451, 9.600405541999999]
-      weight: 2.938193733901249
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 6.070223600017436
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 5.992062677519141
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.942580349475589
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: 8.675305833845833
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 5.026382289051357
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 2.2999340670602617
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: 9.066263601721714
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.791903025133938
       position: [3.3518260619999998, 4.418451, 12.477040374499998]
       weight: 3.974322538073718
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.091038034705714
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-      weight: 2.939772929768324
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 7.364085, 10.321017096]
-      weight: 5.992062677519141
+      site_index: 2
+      distance: 5.026382289051357
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 2.2999340670602617
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 7.364085, 10.774305009]
-      weight: 5.684178177957948
-    - element: Te
+      site_index: 2
+      distance: 5.026382289051357
+      position: [5.013415050000001, 7.364085, 3.789022042]
+      weight: 2.2999340670602613
+    - element: Cs
       kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 7.364085, 7.113133404]
-      weight: 9.066263601721714
+      site_index: 3
+      distance: 4.597145765930607
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 4.471081428738642
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 6.070223600017436
     - element: Cs
       kind:
       site_index: 4
@@ -544,10 +496,58 @@ ref:
       weight: 6.070223600017434
     - element: Cs
       kind:
-      site_index: 2
-      distance: 5.026382289051357
-      position: [5.013415050000001, 7.364085, 3.789022042]
-      weight: 2.2999340670602613
+      site_index: 6
+      distance: 5.091038034705714
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+      weight: 2.939772929768324
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.091038034705715
+      position: [9.31062795, 4.418451, 9.600405541999999]
+      weight: 2.938193733901249
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 1.472817, 10.774305009]
+      weight: 5.684178177957947
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 7.364085, 10.774305009]
+      weight: 5.684178177957948
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.942580349475589
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: 8.675305833845833
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: 9.066263601721714
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 7.364085, 7.113133404]
+      weight: 9.066263601721714
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 5.992062677519141
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 7.364085, 10.321017096]
+      weight: 5.992062677519141
   - Cs: 10
     Te: 5
     element: Cs
@@ -560,82 +560,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.78627208103842
-      position: [8.126507062, 4.418451, 4.962921509000002]
-      weight: 3.991956381159493
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 1.472817, 10.774305009000003]
-      weight: 6.070700716536407
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [14.085308950000002, 4.418451, 7.833744958000002]
-      weight: 2.9397729297683193
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4815768475544395
-      position: [10.972216938, 7.364085, 6.659845491000001]
-      weight: 5.679405475498817
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 7.364085, 10.321017096000002]
-      weight: 9.073570525163188
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 1.472817, 10.321017096000002]
-      weight: 9.073570525163186
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.600777094952303
       position: [12.901188062000001, 4.418451, 12.4770403745]
       weight: 4.459908669736877
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 4.427608797642319
-      position: [7.133373414, 7.364085, 7.113133404000002]
-      weight: 5.98391924905237
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [4.53594695, 4.418451, 7.833744958000002]
-      weight: 2.938193733901249
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.9425803494755898
-      position: [7.190669586, 4.418451, 12.924516904000003]
-      weight: 8.676456221111449
-    - element: Cs
-      kind:
-      site_index: 1
-      distance: 5.026564071967438
-      position: [9.790005922399999, 7.364085, 13.645128458]
-      weight: 2.30016047520391
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 4.427608797642319
-      position: [7.133373414, 1.472817, 7.113133404000002]
-      weight: 5.983919249052372
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 7.364085, 10.774305009000003]
-      weight: 6.070700716536406
     - element: Cs
       kind:
       site_index: 1
@@ -644,10 +572,82 @@ ref:
       weight: 2.30016047520391
     - element: Cs
       kind:
+      site_index: 1
+      distance: 5.026564071967438
+      position: [9.790005922399999, 7.364085, 13.645128458]
+      weight: 2.30016047520391
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.78627208103842
+      position: [8.126507062, 4.418451, 4.962921509000002]
+      weight: 3.991956381159493
+    - element: Cs
+      kind:
       site_index: 4
       distance: 4.4815768475544395
       position: [10.972216938, 1.472817, 6.659845491000001]
       weight: 5.679405475498818
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4815768475544395
+      position: [10.972216938, 7.364085, 6.659845491000001]
+      weight: 5.679405475498817
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [4.53594695, 4.418451, 7.833744958000002]
+      weight: 2.938193733901249
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [14.085308950000002, 4.418451, 7.833744958000002]
+      weight: 2.9397729297683193
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 1.472817, 10.774305009000003]
+      weight: 6.070700716536407
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 7.364085, 10.774305009000003]
+      weight: 6.070700716536406
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.9425803494755898
+      position: [7.190669586, 4.418451, 12.924516904000003]
+      weight: 8.676456221111449
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 4.427608797642319
+      position: [7.133373414, 1.472817, 7.113133404000002]
+      weight: 5.983919249052372
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 4.427608797642319
+      position: [7.133373414, 7.364085, 7.113133404000002]
+      weight: 5.98391924905237
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 1.472817, 10.321017096000002]
+      weight: 9.073570525163186
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 7.364085, 10.321017096000002]
+      weight: 9.073570525163188
   - Cs: 8
     Te: 4
     element: Cs
@@ -658,30 +658,24 @@ ref:
     max_dist: 4.78627208103842
     avg_dist: 4.2758655716662615
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.778884663858416
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: 9.126633518453398
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 5.684178177957947
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.8655128422796166
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 8.386179208198325
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, -1.472817, 12.477040374499998]
+      weight: 4.578167209777737
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-      weight: 5.68417817795795
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, 4.418451, 12.477040374499998]
+      weight: 4.57816720977774
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 4.5986376095690735
+      position: [9.790005922399999, 1.472817, 13.645128457999999]
+      weight: 4.467273737659044
     - element: Cs
       kind:
       site_index: 2
@@ -690,28 +684,16 @@ ref:
       weight: 3.990641973903681
     - element: Cs
       kind:
-      site_index: 1
-      distance: 4.5986376095690735
-      position: [9.790005922399999, 1.472817, 13.645128457999999]
-      weight: 4.467273737659044
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, -1.472817, 12.924516904]
-      weight: 9.098008677046026
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, 4.418451, 12.924516904]
-      weight: 9.098008677046026
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 5.68417817795795
     - element: Cs
       kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, 4.418451, 12.477040374499998]
-      weight: 4.57816720977774
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 5.684178177957947
     - element: Cs
       kind:
       site_index: 6
@@ -724,12 +706,30 @@ ref:
       distance: 4.443663071808786
       position: [9.31062795, 4.418451, 9.600405541999999]
       weight: 6.070700716536407
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, -1.472817, 12.477040374499998]
-      weight: 4.578167209777737
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, -1.472817, 12.924516904]
+      weight: 9.098008677046026
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, 4.418451, 12.924516904]
+      weight: 9.098008677046026
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.778884663858416
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: 9.126633518453398
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.8655128422796166
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 8.386179208198325
   - Cs: 9
     Te: 0
     element: Te
@@ -742,10 +742,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 1
-      distance: 3.9940693613711393
-      position: [9.790005922399999, 7.364085, 2.022361458]
-      weight: 9.063586664858759
+      site_index: 0
+      distance: 3.864835681657127
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      weight: 8.379713700118263
     - element: Cs
       kind:
       site_index: 1
@@ -754,16 +754,16 @@ ref:
       weight: 9.06358666485876
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9425803494755884
-      position: [9.31062795, 4.418451, -2.0223614580000002]
-      weight: 8.676456221111458
+      site_index: 1
+      distance: 3.9940693613711393
+      position: [9.790005922399999, 7.364085, 2.022361458]
+      weight: 9.063586664858759
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.7797467240736218
-      position: [6.197535938000001, 7.364085, -0.8484619909999994]
-      weight: 9.098008677046026
+      site_index: 2
+      distance: 4.427608797642319
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 5.9798665352215465
     - element: Cs
       kind:
       site_index: 2
@@ -778,10 +778,10 @@ ref:
       weight: 9.130139861067637
     - element: Cs
       kind:
-      site_index: 2
-      distance: 4.427608797642319
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 5.9798665352215465
+      site_index: 6
+      distance: 3.9425803494755884
+      position: [9.31062795, 4.418451, -2.0223614580000002]
+      weight: 8.676456221111458
     - element: Cs
       kind:
       site_index: 7
@@ -790,10 +790,10 @@ ref:
       weight: 9.098008677046028
     - element: Cs
       kind:
-      site_index: 0
-      distance: 3.864835681657127
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-      weight: 8.379713700118263
+      site_index: 7
+      distance: 3.7797467240736218
+      position: [6.197535938000001, 7.364085, -0.8484619909999994]
+      weight: 9.098008677046026
   - Cs: 9
     Te: 0
     element: Te
@@ -812,12 +812,6 @@ ref:
       weight: 9.136684294912694
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.779746724073622
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 9.090981838040085
-    - element: Cs
-      kind:
       site_index: 1
       distance: 4.426669939794483
       position: [0.24064392240000002, 1.472817, 2.022361458]
@@ -828,12 +822,6 @@ ref:
       distance: 4.426669939794483
       position: [0.24064392240000002, 7.364085, 2.022361458]
       weight: 5.978058839098269
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 3.942580349475589
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 8.675305833845833
     - element: Cs
       kind:
       site_index: 2
@@ -856,8 +844,20 @@ ref:
       kind:
       site_index: 4
       distance: 3.779746724073622
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 9.090981838040085
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.779746724073622
       position: [1.422854938, 7.364085, 6.659845491]
       weight: 9.090981838040081
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.942580349475589
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 8.675305833845833
   - Cs: 9
     Te: 0
     element: Te
@@ -870,22 +870,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 3.779746724073622
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 9.092627235305683
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 3.778884663858416
-      position: [6.197535938000001, 1.472817, 10.774305009]
-      weight: 9.126633518453398
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.427608797642319
-      position: [9.31062795, 4.418451, 9.600405541999999]
-      weight: 5.983919249052372
+      site_index: 2
+      distance: 3.942580349475588
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 8.675443200804002
     - element: Cs
       kind:
       site_index: 3
@@ -894,15 +882,27 @@ ref:
       weight: 9.092627235305681
     - element: Cs
       kind:
-      site_index: 2
-      distance: 3.942580349475588
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 8.675443200804002
+      site_index: 3
+      distance: 3.779746724073622
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 9.092627235305683
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.8655128422796166
+      position: [10.972216938, 1.472817, 6.659845491]
+      weight: 8.376535496535926
     - element: Cs
       kind:
       site_index: 5
       distance: 3.9928266816381903
       position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 9.066263601721714
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.9928266816381903
+      position: [4.53594695, 4.418451, 7.8337449580000005]
       weight: 9.066263601721714
     - element: Cs
       kind:
@@ -912,16 +912,16 @@ ref:
       weight: 5.983919249052372
     - element: Cs
       kind:
-      site_index: 5
-      distance: 3.9928266816381903
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 9.066263601721714
+      site_index: 6
+      distance: 4.427608797642319
+      position: [9.31062795, 4.418451, 9.600405541999999]
+      weight: 5.983919249052372
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.8655128422796166
-      position: [10.972216938, 1.472817, 6.659845491]
-      weight: 8.376535496535926
+      site_index: 7
+      distance: 3.778884663858416
+      position: [6.197535938000001, 1.472817, 10.774305009]
+      weight: 9.126633518453398
   - Cs: 9
     Te: 0
     element: Te
@@ -934,34 +934,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.865512842279617
-      position: [6.1975359380000015, 1.472817, 10.774305009]
-      weight: 8.386179208198325
-    - element: Cs
-      kind:
       site_index: 0
       distance: 3.783055706988686
       position: [3.351826062, -1.472817, 12.477040374499998]
       weight: 9.083184602198688
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 3.778884663858416
-      position: [1.4228549380000004, 1.472817, 6.659845491]
-      weight: 9.126633518453398
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
-      weight: 9.073570525163184
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.427608797642319
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 5.992062677519141
     - element: Cs
       kind:
       site_index: 0
@@ -970,72 +946,96 @@ ref:
       weight: 9.08318460219869
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
-      weight: 9.073570525163179
-    - element: Cs
-      kind:
       site_index: 1
       distance: 3.9415537240720844
       position: [0.24064392240000046, 1.472817, 13.645128457999999]
       weight: 8.677363336522946
     - element: Cs
       kind:
+      site_index: 4
+      distance: 3.778884663858416
+      position: [1.4228549380000004, 1.472817, 6.659845491]
+      weight: 9.126633518453398
+    - element: Cs
+      kind:
       site_index: 5
       distance: 4.427608797642319
       position: [4.53594695, -1.472817, 7.8337449580000005]
       weight: 5.992062677519144
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.427608797642319
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 5.992062677519141
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
+      weight: 9.073570525163184
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
+      weight: 9.073570525163179
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 3.865512842279617
+      position: [6.1975359380000015, 1.472817, 10.774305009]
+      weight: 8.386179208198325
   nrs_avg:
-    &id001 [Cs, Cs]: 9
-    &id002 [Cs, Te]: 4.5
-    &id003 [Te, Cs]: 9
-    &id004 [Te, Te]: 0
+    [Cs, Cs]: 9
+    [Cs, Te]: 4.5
+    [Te, Cs]: 9
+    [Te, Te]: 0
   nrs_stdev:
-    *id001 : 1.0690449676496976
-    *id002 : 0.5345224838248488
-    *id003 : 0.0
-    *id004 : 0.0
+    [Cs, Cs]: 1.0690449676496976
+    [Cs, Te]: 0.5345224838248488
+    [Te, Cs]: 0.0
+    [Te, Te]: 0.0
   nrs_max:
-    *id001 : 10
-    *id002 : 5
-    *id003 : 9
-    *id004 : 0
+    [Cs, Cs]: 10
+    [Cs, Te]: 5
+    [Te, Cs]: 9
+    [Te, Te]: 0
   nrs_min:
-    *id001 : 8
-    *id002 : 4
-    *id003 : 9
-    *id004 : 0
+    [Cs, Cs]: 8
+    [Cs, Te]: 4
+    [Te, Cs]: 9
+    [Te, Te]: 0
   distance_avg:
-    &id005 [Cs, Te]: 3.9985905774904276
-    &id006 [Cs, Cs]: 4.642825840593194
-    &id007 [Te, Cs]: 3.998590577490427
+    [Cs, Te]: 3.9985905774904276
+    [Cs, Cs]: 4.642825840593194
+    [Te, Cs]: 3.998590577490427
   distance_stdev:
-    *id005 : 0.24672846215561214
-    *id006 : 0.24822823441566136
-    *id007 : 0.24672846215561223
+    [Cs, Te]: 0.24672846215561214
+    [Cs, Cs]: 0.24822823441566136
+    [Te, Cs]: 0.24672846215561223
   distance_max:
-    *id005 : 4.4276087976423195
-    *id006 : 5.092829270783992
-    *id007 : 4.4276087976423195
+    [Cs, Te]: 4.4276087976423195
+    [Cs, Cs]: 5.092829270783992
+    [Te, Cs]: 4.4276087976423195
   distance_min:
-    *id005 : 3.7732545806519044
-    *id006 : 4.433325541961324
-    *id007 : 3.7732545806519044
-  weight_avg: 
-    *id005 : 8.273783419306273 
-    *id006 : 4.642830227835206
-    *id007 : 8.273783419306273
-  weight_stdev: 
-    *id005 : 1.2641935273815492
-    *id006 : 1.3051528493492641
-    *id007 : 1.264193527381549
-  weight_max: 
-    *id005 : 9.136684294912694
-    *id006 : 6.079962079108368
-    *id007 : 9.136684294912694
-  weight_min: 
-    *id005 : 5.9780588390982725
-    *id006 : 2.2999340670602595
-    *id007 : 5.978058839098272
+    [Cs, Te]: 3.7732545806519044
+    [Cs, Cs]: 4.433325541961324
+    [Te, Cs]: 3.7732545806519044
+  weight_avg:
+    [Cs, Te]: 8.273783419306273
+    [Cs, Cs]: 4.642830227835206
+    [Te, Cs]: 8.273783419306273
+  weight_stdev:
+    [Cs, Te]: 1.2641935273815492
+    [Cs, Cs]: 1.3051528493492641
+    [Te, Cs]: 1.264193527381549
+  weight_max:
+    [Cs, Te]: 9.136684294912694
+    [Cs, Cs]: 6.079962079108368
+    [Te, Cs]: 9.136684294912694
+  weight_min:
+    [Cs, Te]: 5.9780588390982725
+    [Cs, Cs]: 2.2999340670602595
+    [Te, Cs]: 5.978058839098272
 parameters: {r_max: 5.0, method: voronoi, voronoi_weight_type: area, voronoi_weight_threshold: 2.0}

--- a/tests/strct/coordination/Cs2Te_62_prim_voronoi_no_weights.yaml
+++ b/tests/strct/coordination/Cs2Te_62_prim_voronoi_no_weights.yaml
@@ -12,46 +12,16 @@ ref:
     max_dist: 5.728023787414882
     avg_dist: 4.387163848206998
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 1.472817, -1.3017499039999998]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.864835681657127
-      position: [7.190669586000001, 4.418451, 1.301749904]
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.477765890306448
-      position: [5.013415050000002, 7.364085, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 7.364085, -1.3017499039999998]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.600777094952304
-      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
     - element: Cs
       kind:
       site_index: 1
       distance: 4.440793142957318
       position: [0.2406439224000009, 1.472817, 2.022361458]
-    - element: Te
+    - element: Cs
       kind:
-      site_index: 8
-      distance: 5.728023787414882
-      position: [-2.358692413999999, 4.418451, 1.301749904]
+      site_index: 1
+      distance: 4.440793142957318
+      position: [0.2406439224000009, 7.364085, 2.022361458]
     - element: Cs
       kind:
       site_index: 2
@@ -59,24 +29,54 @@ ref:
       position: [5.013415050000002, 1.472817, 3.789022042]
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
+      site_index: 2
+      distance: 4.477765890306448
+      position: [5.013415050000002, 7.364085, 3.789022042]
     - element: Cs
       kind:
       site_index: 5
       distance: 4.79190302513394
       position: [4.5359469500000005, 4.418451, -3.7890220419999996]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.600777094952304
+      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 5.728023787414882
+      position: [-2.358692413999999, 4.418451, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.864835681657127
+      position: [7.190669586000001, 4.418451, 1.301749904]
     - element: Te
       kind:
       site_index: 9
       distance: 3.773254580651904
       position: [2.415988586000001, 4.418451, 4.509633596]
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 1
-      distance: 4.440793142957318
-      position: [0.2406439224000009, 7.364085, 2.022361458]
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 1.472817, -1.3017499039999998]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 7.364085, -1.3017499039999998]
   - Cs: 12
     Te: 6
     element: Cs
@@ -89,14 +89,9 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.598637609569076
-      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9415537240720857
-      position: [2.358692414, 1.472817, -1.3017499039999998]
+      site_index: 0
+      distance: 4.440793142957318
+      position: [3.3518260619999998, -1.472817, 0.8542733745]
     - element: Cs
       kind:
       site_index: 0
@@ -104,64 +99,9 @@ ref:
       position: [3.3518260619999998, 4.418451, 0.8542733745]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, -1.472817, 1.301749904]
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.440793142957318
-      position: [3.3518260619999998, -1.472817, 0.8542733745]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, 4.418451, 1.301749904]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 5.742269176106977
-      position: [-2.415988586, 1.472817, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.785799937495917
-      position: [1.422854938, 1.472817, 6.659845491]
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 5.089246884904623
-      position: [5.013415050000001, 1.472817, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 4.426669939794483
-      position: [2.415988586, -1.472817, 4.509633596]
-    - element: Cs
-      kind:
       site_index: 1
       distance: 5.891268
       position: [0.24064392240000002, -4.418451, 2.022361458]
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.4822853026157565
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 4.426669939794483
-      position: [2.415988586, 4.418451, 4.509633596]
     - element: Cs
       kind:
       site_index: 1
@@ -174,9 +114,69 @@ ref:
       position: [-4.53594695, 1.472817, 3.789022042]
     - element: Cs
       kind:
+      site_index: 2
+      distance: 5.089246884904623
+      position: [5.013415050000001, 1.472817, 3.789022042]
+    - element: Cs
+      kind:
       site_index: 3
       distance: 4.4822853026157565
       position: [-1.4228549380000002, -1.472817, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.4822853026157565
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.785799937495917
+      position: [1.422854938, 1.472817, 6.659845491]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.598637609569076
+      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, -1.472817, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, 4.418451, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 4.426669939794483
+      position: [2.415988586, -1.472817, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 4.426669939794483
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 5.742269176106977
+      position: [-2.415988586, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9415537240720857
+      position: [2.358692414, 1.472817, -1.3017499039999998]
   - Cs: 12
     Te: 6
     element: Cs
@@ -187,26 +187,6 @@ ref:
     max_dist: 5.891268
     avg_dist: 4.764916091430962
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 5.7413858327298835
-      position: [2.358692414, 1.472817, -1.3017499039999998]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 4.427608797642319
-      position: [7.190669586, 4.418451, 1.301749904]
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.477765890306448
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.443663071808785
-      position: [8.126507062, 4.418451, 4.962921509]
     - element: Cs
       kind:
       site_index: 0
@@ -214,54 +194,24 @@ ref:
       position: [3.3518260619999998, -1.472817, 0.8542733745]
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.78627208103842
-      position: [6.197535938000001, 1.472817, -0.8484619909999994]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.597145765930607
-      position: [1.422854938, 1.472817, 6.659845491]
+      site_index: 0
+      distance: 4.477765890306448
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
     - element: Cs
       kind:
       site_index: 1
       distance: 5.089246884904623
       position: [0.24064392240000002, 1.472817, 2.022361458]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, 4.418451, 4.509633596]
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.443663071808785
-      position: [8.126507062, -1.472817, 4.962921509]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 4.427608797642319
-      position: [7.190669586, -1.472817, 1.301749904]
+      site_index: 1
+      distance: 5.092829270783991
+      position: [9.790005922399999, 1.472817, 2.022361458]
     - element: Cs
       kind:
       site_index: 2
       distance: 5.891268
       position: [5.013415050000001, -4.418451, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, -1.472817, 4.509633596]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.942580349475588
-      position: [7.133373414, 1.472817, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.026382289051357
-      position: [4.53594695, 4.418451, 7.8337449580000005]
     - element: Cs
       kind:
       site_index: 2
@@ -269,14 +219,64 @@ ref:
       position: [5.013415050000001, 7.364085, 3.789022042]
     - element: Cs
       kind:
+      site_index: 3
+      distance: 4.443663071808785
+      position: [8.126507062, -1.472817, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.443663071808785
+      position: [8.126507062, 4.418451, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.597145765930607
+      position: [1.422854938, 1.472817, 6.659845491]
+    - element: Cs
+      kind:
       site_index: 5
       distance: 5.026382289051357
       position: [4.53594695, -1.472817, 7.8337449580000005]
     - element: Cs
       kind:
-      site_index: 1
-      distance: 5.092829270783991
-      position: [9.790005922399999, 1.472817, 2.022361458]
+      site_index: 5
+      distance: 5.026382289051357
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.78627208103842
+      position: [6.197535938000001, 1.472817, -0.8484619909999994]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 4.427608797642319
+      position: [7.190669586, -1.472817, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 4.427608797642319
+      position: [7.190669586, 4.418451, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, -1.472817, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.942580349475588
+      position: [7.133373414, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 5.7413858327298835
+      position: [2.358692414, 1.472817, -1.3017499039999998]
   - Cs: 8
     Te: 5
     element: Cs
@@ -287,16 +287,6 @@ ref:
     max_dist: 5.728480705807541
     avg_dist: 4.387256718448737
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.778884663858415
-      position: [7.190669586, 4.418451, 1.301749904]
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.443663071808785
-      position: [5.013415050000001, 1.472817, 3.789022042]
     - element: Cs
       kind:
       site_index: 1
@@ -311,17 +301,12 @@ ref:
       kind:
       site_index: 2
       distance: 4.443663071808785
+      position: [5.013415050000001, 1.472817, 3.789022042]
+    - element: Cs
+      kind:
+      site_index: 2
+      distance: 4.443663071808785
       position: [5.013415050000001, 7.364085, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.779746724073622
-      position: [7.133373414, 7.364085, 7.113133404]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.8655128422796174
-      position: [11.965350586000001, 4.418451, 4.509633596]
     - element: Cs
       kind:
       site_index: 4
@@ -329,19 +314,14 @@ ref:
       position: [10.972216938, 1.472817, 6.659845491]
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.597145765930607
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 5.728480705807541
-      position: [2.415988586, 4.418451, 4.509633596]
-    - element: Cs
-      kind:
       site_index: 4
       distance: 4.433325541961325
       position: [10.972216938, 7.364085, 6.659845491]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.597145765930607
+      position: [4.53594695, 4.418451, 7.8337449580000005]
     - element: Cs
       kind:
       site_index: 6
@@ -349,9 +329,29 @@ ref:
       position: [9.31062795, 4.418451, 9.600405541999999]
     - element: Te
       kind:
+      site_index: 8
+      distance: 3.778884663858415
+      position: [7.190669586, 4.418451, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 5.728480705807541
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.8655128422796174
+      position: [11.965350586000001, 4.418451, 4.509633596]
+    - element: Te
+      kind:
       site_index: 10
       distance: 3.779746724073622
       position: [7.133373414, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.779746724073622
+      position: [7.133373414, 7.364085, 7.113133404]
   - Cs: 8
     Te: 5
     element: Cs
@@ -362,51 +362,6 @@ ref:
     max_dist: 5.728480705807541
     avg_dist: 4.387111406628342
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.865512842279616
-      position: [-2.415988586, 1.472817, 7.113133404]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 5.728480705807541
-      position: [7.133373414, 1.472817, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, -1.472817, 4.509633596]
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.433325541961324
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, 4.418451, 4.509633596]
     - element: Cs
       kind:
       site_index: 1
@@ -417,16 +372,61 @@ ref:
       site_index: 2
       distance: 4.597145765930607
       position: [5.013415050000001, 1.472817, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.778884663858416
-      position: [2.358692414, 1.472817, 10.321017096]
     - element: Cs
       kind:
       site_index: 3
       distance: 4.433325541961324
       position: [-1.4228549380000002, -1.472817, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.433325541961324
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, -1.472817, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.865512842279616
+      position: [-2.415988586, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 5.728480705807541
+      position: [7.133373414, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.778884663858416
+      position: [2.358692414, 1.472817, 10.321017096]
   - Cs: 12
     Te: 6
     element: Cs
@@ -439,84 +439,14 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.597145765930607
-      position: [8.126507062, 4.418451, 4.962921509]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 1.472817, 10.774305009]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.091038034705715
-      position: [9.31062795, 4.418451, 9.600405541999999]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 1.472817, 6.659845491]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 1.472817, 10.321017096]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.942580349475589
-      position: [2.415988586, 4.418451, 4.509633596]
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 5.026382289051357
-      position: [5.013415050000001, 1.472817, 3.789022042]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 1.472817, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.891268
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 5.7413858327298835
-      position: [7.190669586, 4.418451, 12.924516904]
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.791903025133938
       position: [3.3518260619999998, 4.418451, 12.477040374499998]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.091038034705714
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 4.427608797642319
-      position: [2.358692414, 7.364085, 10.321017096]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 7.364085, 10.774305009]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 7.364085, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 7.364085, 6.659845491]
+      site_index: 2
+      distance: 5.026382289051357
+      position: [5.013415050000001, 1.472817, 3.789022042]
     - element: Cs
       kind:
       site_index: 2
@@ -524,9 +454,79 @@ ref:
       position: [5.013415050000001, 7.364085, 3.789022042]
     - element: Cs
       kind:
+      site_index: 3
+      distance: 4.597145765930607
+      position: [8.126507062, 4.418451, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 1.472817, 6.659845491]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 7.364085, 6.659845491]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.891268
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+    - element: Cs
+      kind:
       site_index: 5
       distance: 5.891268000000001
       position: [4.53594695, 10.309719000000001, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.091038034705714
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.091038034705715
+      position: [9.31062795, 4.418451, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 1.472817, 10.774305009]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 7.364085, 10.774305009]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 5.7413858327298835
+      position: [7.190669586, 4.418451, 12.924516904]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.942580349475589
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 7.364085, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 1.472817, 10.321017096]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 4.427608797642319
+      position: [2.358692414, 7.364085, 10.321017096]
   - Cs: 12
     Te: 6
     element: Cs
@@ -539,79 +539,9 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.78627208103842
-      position: [8.126507062, 4.418451, 4.962921509000002]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 1.472817, 10.774305009000003]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [14.085308950000002, 4.418451, 7.833744958000002]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4815768475544395
-      position: [10.972216938, 7.364085, 6.659845491000001]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 7.364085, 10.321017096000002]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 5.741385832729883
-      position: [11.965350586000001, 4.418451, 4.509633596000001]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 1.472817, 10.321017096000002]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.891268
-      position: [9.31062795, -1.472817, 9.600405542]
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.600777094952303
       position: [12.901188062000001, 4.418451, 12.4770403745]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 4.427608797642319
-      position: [7.133373414, 7.364085, 7.113133404000002]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [4.53594695, 4.418451, 7.833744958000002]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.9425803494755898
-      position: [7.190669586, 4.418451, 12.924516904000003]
-    - element: Cs
-      kind:
-      site_index: 1
-      distance: 5.026564071967438
-      position: [9.790005922399999, 7.364085, 13.645128458]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 4.427608797642319
-      position: [7.133373414, 1.472817, 7.113133404000002]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 7.364085, 10.774305009000003]
     - element: Cs
       kind:
       site_index: 1
@@ -619,14 +549,84 @@ ref:
       position: [9.790005922399999, 1.472817, 13.645128458]
     - element: Cs
       kind:
+      site_index: 1
+      distance: 5.026564071967438
+      position: [9.790005922399999, 7.364085, 13.645128458]
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.78627208103842
+      position: [8.126507062, 4.418451, 4.962921509000002]
+    - element: Cs
+      kind:
       site_index: 4
       distance: 4.4815768475544395
       position: [10.972216938, 1.472817, 6.659845491000001]
     - element: Cs
       kind:
+      site_index: 4
+      distance: 4.4815768475544395
+      position: [10.972216938, 7.364085, 6.659845491000001]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [4.53594695, 4.418451, 7.833744958000002]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [14.085308950000002, 4.418451, 7.833744958000002]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.891268
+      position: [9.31062795, -1.472817, 9.600405542]
+    - element: Cs
+      kind:
       site_index: 6
       distance: 5.891268000000001
       position: [9.31062795, 10.309719000000001, 9.600405542]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 1.472817, 10.774305009000003]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 7.364085, 10.774305009000003]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.9425803494755898
+      position: [7.190669586, 4.418451, 12.924516904000003]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 5.741385832729883
+      position: [11.965350586000001, 4.418451, 4.509633596000001]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 4.427608797642319
+      position: [7.133373414, 1.472817, 7.113133404000002]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 4.427608797642319
+      position: [7.133373414, 7.364085, 7.113133404000002]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 1.472817, 10.321017096000002]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 7.364085, 10.321017096000002]
   - Cs: 8
     Te: 5
     element: Cs
@@ -637,26 +637,21 @@ ref:
     max_dist: 5.728480705807538
     avg_dist: 4.387605197369437
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.778884663858416
-      position: [7.133373414, 1.472817, 7.113133404]
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.8655128422796166
-      position: [2.358692414, 1.472817, 10.321017096]
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, -1.472817, 12.477040374499998]
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, -1.472817, 7.8337449580000005]
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, 4.418451, 12.477040374499998]
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 4.5986376095690735
+      position: [9.790005922399999, 1.472817, 13.645128457999999]
     - element: Cs
       kind:
       site_index: 2
@@ -664,24 +659,14 @@ ref:
       position: [5.013415050000001, 1.472817, 15.411789042]
     - element: Cs
       kind:
-      site_index: 1
-      distance: 4.5986376095690735
-      position: [9.790005922399999, 1.472817, 13.645128457999999]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, -1.472817, 12.924516904]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, 4.418451, 12.924516904]
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, -1.472817, 7.8337449580000005]
     - element: Cs
       kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, 4.418451, 12.477040374499998]
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, 4.418451, 7.8337449580000005]
     - element: Cs
       kind:
       site_index: 6
@@ -694,14 +679,29 @@ ref:
       position: [9.31062795, 4.418451, 9.600405541999999]
     - element: Te
       kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, -1.472817, 12.924516904]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, 4.418451, 12.924516904]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.778884663858416
+      position: [7.133373414, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.8655128422796166
+      position: [2.358692414, 1.472817, 10.321017096]
+    - element: Te
+      kind:
       site_index: 11
       distance: 5.728480705807538
       position: [11.908054413999999, 1.472817, 10.321017096]
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, -1.472817, 12.477040374499998]
   - Cs: 11
     Te: 2
     element: Te
@@ -714,14 +714,14 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 1
-      distance: 3.9940693613711393
-      position: [9.790005922399999, 7.364085, 2.022361458]
-    - element: Te
+      site_index: 0
+      distance: 3.864835681657127
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+    - element: Cs
       kind:
-      site_index: 9
-      distance: 5.752225346173475
-      position: [11.965350586000001, 4.418451, 4.509633596]
+      site_index: 0
+      distance: 5.728023787414883
+      position: [12.901188062000001, 4.418451, 0.8542733745]
     - element: Cs
       kind:
       site_index: 1
@@ -729,19 +729,14 @@ ref:
       position: [9.790005922399999, 1.472817, 2.022361458]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9425803494755884
-      position: [9.31062795, 4.418451, -2.0223614580000002]
+      site_index: 1
+      distance: 3.9940693613711393
+      position: [9.790005922399999, 7.364085, 2.022361458]
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.7797467240736218
-      position: [6.197535938000001, 7.364085, -0.8484619909999994]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.741385832729883
-      position: [4.53594695, 4.418451, -3.7890220419999996]
+      site_index: 2
+      distance: 4.427608797642319
+      position: [5.013415050000001, 1.472817, 3.789022042]
     - element: Cs
       kind:
       site_index: 2
@@ -754,19 +749,14 @@ ref:
       position: [8.126507062, 4.418451, 4.962921509]
     - element: Cs
       kind:
-      site_index: 2
-      distance: 4.427608797642319
-      position: [5.013415050000001, 1.472817, 3.789022042]
+      site_index: 5
+      distance: 5.741385832729883
+      position: [4.53594695, 4.418451, -3.7890220419999996]
     - element: Cs
       kind:
-      site_index: 0
-      distance: 5.728023787414883
-      position: [12.901188062000001, 4.418451, 0.8542733745]
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 5.752225346173474
-      position: [2.415988586, 4.418451, 4.509633596]
+      site_index: 6
+      distance: 3.9425803494755884
+      position: [9.31062795, 4.418451, -2.0223614580000002]
     - element: Cs
       kind:
       site_index: 7
@@ -774,9 +764,19 @@ ref:
       position: [6.197535938000001, 1.472817, -0.8484619909999994]
     - element: Cs
       kind:
-      site_index: 0
-      distance: 3.864835681657127
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      site_index: 7
+      distance: 3.7797467240736218
+      position: [6.197535938000001, 7.364085, -0.8484619909999994]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 5.752225346173474
+      position: [2.415988586, 4.418451, 4.509633596]
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 5.752225346173475
+      position: [11.965350586000001, 4.418451, 4.509633596]
   - Cs: 11
     Te: 2
     element: Te
@@ -787,31 +787,11 @@ ref:
     max_dist: 5.752225346173474
     avg_dist: 4.534934745715698
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 5.752225346173474
-      position: [7.190669586, 4.418451, 1.301749904]
     - element: Cs
       kind:
       site_index: 0
       distance: 3.773254580651904
       position: [3.3518260619999998, 4.418451, 0.8542733745]
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 5.728480705807541
-      position: [8.126507062, 4.418451, 4.962921509]
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 5.752225346173474
-      position: [-2.358692414, 4.418451, 1.301749904]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 3.779746724073622
-      position: [1.422854938, 1.472817, 6.659845491]
     - element: Cs
       kind:
       site_index: 1
@@ -822,11 +802,6 @@ ref:
       site_index: 1
       distance: 4.426669939794483
       position: [0.24064392240000002, 7.364085, 2.022361458]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 3.942580349475589
-      position: [4.53594695, 4.418451, 7.8337449580000005]
     - element: Cs
       kind:
       site_index: 2
@@ -844,14 +819,39 @@ ref:
       position: [-1.4228549380000002, 4.418451, 4.962921509]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.741385832729883
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+      site_index: 3
+      distance: 5.728480705807541
+      position: [8.126507062, 4.418451, 4.962921509]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.779746724073622
+      position: [1.422854938, 1.472817, 6.659845491]
     - element: Cs
       kind:
       site_index: 4
       distance: 3.779746724073622
       position: [1.422854938, 7.364085, 6.659845491]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.942580349475589
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.741385832729883
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 5.752225346173474
+      position: [-2.358692414, 4.418451, 1.301749904]
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 5.752225346173474
+      position: [7.190669586, 4.418451, 1.301749904]
   - Cs: 11
     Te: 2
     element: Te
@@ -864,34 +864,9 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 3.779746724073622
-      position: [8.126507062, 4.418451, 4.962921509]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 3.778884663858416
-      position: [6.197535938000001, 1.472817, 10.774305009]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.427608797642319
-      position: [9.31062795, 4.418451, 9.600405541999999]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 5.728480705807541
-      position: [1.422854938, 1.472817, 6.659845491]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 5.752225346173475
-      position: [2.358692414, 1.472817, 10.321017096]
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 3.779746724073622
-      position: [8.126507062, -1.472817, 4.962921509]
+      site_index: 1
+      distance: 5.742269176106976
+      position: [9.790005922399999, 1.472817, 2.022361458]
     - element: Cs
       kind:
       site_index: 2
@@ -899,24 +874,19 @@ ref:
       position: [5.013415050000001, 1.472817, 3.789022042]
     - element: Cs
       kind:
-      site_index: 5
-      distance: 3.9928266816381903
-      position: [4.53594695, -1.472817, 7.8337449580000005]
+      site_index: 3
+      distance: 3.779746724073622
+      position: [8.126507062, -1.472817, 4.962921509]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 4.427608797642319
-      position: [9.31062795, -1.472817, 9.600405541999999]
+      site_index: 3
+      distance: 3.779746724073622
+      position: [8.126507062, 4.418451, 4.962921509]
     - element: Cs
       kind:
-      site_index: 5
-      distance: 3.9928266816381903
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 5.752225346173473
-      position: [11.908054413999999, 1.472817, 10.321017096]
+      site_index: 4
+      distance: 5.728480705807541
+      position: [1.422854938, 1.472817, 6.659845491]
     - element: Cs
       kind:
       site_index: 4
@@ -924,9 +894,39 @@ ref:
       position: [10.972216938, 1.472817, 6.659845491]
     - element: Cs
       kind:
-      site_index: 1
-      distance: 5.742269176106976
-      position: [9.790005922399999, 1.472817, 2.022361458]
+      site_index: 5
+      distance: 3.9928266816381903
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.9928266816381903
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.427608797642319
+      position: [9.31062795, -1.472817, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.427608797642319
+      position: [9.31062795, 4.418451, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 3.778884663858416
+      position: [6.197535938000001, 1.472817, 10.774305009]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 5.752225346173475
+      position: [2.358692414, 1.472817, 10.321017096]
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 5.752225346173473
+      position: [11.908054413999999, 1.472817, 10.321017096]
   - Cs: 11
     Te: 2
     element: Te
@@ -939,39 +939,9 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.865512842279617
-      position: [6.1975359380000015, 1.472817, 10.774305009]
-    - element: Cs
-      kind:
       site_index: 0
       distance: 3.783055706988686
       position: [3.351826062, -1.472817, 12.477040374499998]
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 5.752225346173475
-      position: [-2.4159885859999997, 1.472817, 7.113133404]
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 3.778884663858416
-      position: [1.4228549380000004, 1.472817, 6.659845491]
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 5.728480705807541
-      position: [-3.3518260619999993, 1.472817, 10.774305009]
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.427608797642319
-      position: [4.53594695, 4.418451, 7.8337449580000005]
     - element: Cs
       kind:
       site_index: 0
@@ -979,19 +949,19 @@ ref:
       position: [3.351826062, 4.418451, 12.477040374499998]
     - element: Cs
       kind:
-      site_index: 6
-      distance: 3.9928266816381903
-      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
-    - element: Cs
-      kind:
       site_index: 1
       distance: 3.9415537240720844
       position: [0.24064392240000046, 1.472817, 13.645128457999999]
-    - element: Te
+    - element: Cs
       kind:
-      site_index: 10
-      distance: 5.752225346173476
-      position: [7.133373414000001, 1.472817, 7.113133404]
+      site_index: 2
+      distance: 5.7413858327298835
+      position: [5.013415050000001, 1.472817, 15.411789042]
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.778884663858416
+      position: [1.4228549380000004, 1.472817, 6.659845491]
     - element: Cs
       kind:
       site_index: 5
@@ -999,47 +969,77 @@ ref:
       position: [4.53594695, -1.472817, 7.8337449580000005]
     - element: Cs
       kind:
-      site_index: 2
-      distance: 5.7413858327298835
-      position: [5.013415050000001, 1.472817, 15.411789042]
+      site_index: 5
+      distance: 4.427608797642319
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, -1.472817, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 3.9928266816381903
+      position: [-0.23873404999999978, 4.418451, 9.600405541999999]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 5.728480705807541
+      position: [-3.3518260619999993, 1.472817, 10.774305009]
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 3.865512842279617
+      position: [6.1975359380000015, 1.472817, 10.774305009]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 5.752225346173475
+      position: [-2.4159885859999997, 1.472817, 7.113133404]
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 5.752225346173476
+      position: [7.133373414000001, 1.472817, 7.113133404]
   nrs_avg:
-    &id001 [Cs, Cs]: 10
-    &id002 [Cs, Te]: 5.5
-    &id003 [Te, Cs]: 11
-    &id004 [Te, Te]: 2
+    [Cs, Cs]: 10
+    [Cs, Te]: 5.5
+    [Te, Cs]: 11
+    [Te, Te]: 2
   nrs_stdev:
-    *id001 : 2.138089935299395
-    *id002 : 0.5345224838248488
-    *id003 : 0.0
-    *id004 : 0.0
+    [Cs, Cs]: 2.138089935299395
+    [Cs, Te]: 0.5345224838248488
+    [Te, Cs]: 0.0
+    [Te, Te]: 0.0
   nrs_max:
-    *id001 : 12
-    *id002 : 6
-    *id003 : 11
-    *id004 : 2
+    [Cs, Cs]: 12
+    [Cs, Te]: 6
+    [Te, Cs]: 11
+    [Te, Te]: 2
   nrs_min:
-    *id001 : 8
-    *id002 : 5
-    *id003 : 11
-    *id004 : 2
+    [Cs, Cs]: 8
+    [Cs, Te]: 5
+    [Te, Cs]: 11
+    [Te, Te]: 2
   distance_avg:
-    &id005 [Cs, Te]: 4.314298940199762
-    &id006 [Cs, Cs]: 4.767670056533875
-    &id007 [Te, Cs]: 4.314298940199762
-    &id008 [Te, Te]: 5.752225346173475
+    [Cs, Te]: 4.314298940199762
+    [Cs, Cs]: 4.767670056533875
+    [Te, Cs]: 4.314298940199762
+    [Te, Te]: 5.752225346173475
   distance_stdev:
-    *id005 : 0.7130997607051229
-    *id006 : 0.444328558220957
-    *id007 : 0.7130997607051228
-    *id008 : 1.0346965462394976e-15
+    [Cs, Te]: 0.7130997607051229
+    [Cs, Cs]: 0.444328558220957
+    [Te, Cs]: 0.7130997607051228
+    [Te, Te]: 1.0346965462394976e-15
   distance_max:
-    *id005 : 5.742269176106977
-    *id006 : 5.891268000000001
-    *id007 : 5.742269176106977
-    *id008 : 5.752225346173477
+    [Cs, Te]: 5.742269176106977
+    [Cs, Cs]: 5.891268000000001
+    [Te, Cs]: 5.742269176106977
+    [Te, Te]: 5.752225346173477
   distance_min:
-    *id005 : 3.7732545806519044
-    *id006 : 4.433325541961324
-    *id007 : 3.7732545806519044
-    *id008 : 5.752225346173474
-parameters: {r_max: 5.0, method: voronoi, voronoi_weight_type: , voronoi_weight_threshold: 0.5}
+    [Cs, Te]: 3.7732545806519044
+    [Cs, Cs]: 4.433325541961324
+    [Te, Cs]: 3.7732545806519044
+    [Te, Te]: 5.752225346173474
+parameters: {r_max: 5.0, method: voronoi, voronoi_weight_type: null, voronoi_weight_threshold: 0.5}

--- a/tests/strct/coordination/Cs2Te_62_prim_voronoi_radius.yaml
+++ b/tests/strct/coordination/Cs2Te_62_prim_voronoi_radius.yaml
@@ -12,47 +12,17 @@ ref:
     max_dist: 4.79190302513394
     avg_dist: 4.275425519939675
     neighbours:
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 1.472817, -1.3017499039999998]
-      weight: 0.03694429301131308
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.864835681657127
-      position: [7.190669586000001, 4.418451, 1.301749904]
-      weight: -0.04483568165712715
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.477765890306448
-      position: [5.013415050000002, 7.364085, 3.789022042]
-      weight: 0.402234109693552
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.7830557069886868
-      position: [2.358692414000001, 7.364085, -1.3017499039999998]
-      weight: 0.03694429301131308
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
-      weight: 0.4444468118120426
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.600777094952304
-      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
-      weight: 0.2792229050476962
     - element: Cs
       kind:
       site_index: 1
       distance: 4.440793142957318
       position: [0.2406439224000009, 1.472817, 2.022361458]
+      weight: 0.4392068570426817
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 4.440793142957318
+      position: [0.2406439224000009, 7.364085, 2.022361458]
       weight: 0.4392068570426817
     - element: Cs
       kind:
@@ -62,28 +32,58 @@ ref:
       weight: 0.402234109693552
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.435553188187957
-      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
-      weight: 0.4444468118120426
+      site_index: 2
+      distance: 4.477765890306448
+      position: [5.013415050000002, 7.364085, 3.789022042]
+      weight: 0.402234109693552
     - element: Cs
       kind:
       site_index: 5
       distance: 4.79190302513394
       position: [4.5359469500000005, 4.418451, -3.7890220419999996]
       weight: 0.08809697486606005
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.600777094952304
+      position: [-0.23873404999999934, 4.418451, -2.0223614580000002]
+      weight: 0.2792229050476962
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 1.472817, -0.8484619909999994]
+      weight: 0.4444468118120426
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.435553188187957
+      position: [6.1975359380000015, 7.364085, -0.8484619909999994]
+      weight: 0.4444468118120426
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.864835681657127
+      position: [7.190669586000001, 4.418451, 1.301749904]
+      weight: -0.04483568165712715
     - element: Te
       kind:
       site_index: 9
       distance: 3.773254580651904
       position: [2.415988586000001, 4.418451, 4.509633596]
       weight: 0.04674541934809584
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 1
-      distance: 4.440793142957318
-      position: [0.2406439224000009, 7.364085, 2.022361458]
-      weight: 0.4392068570426817
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 1.472817, -1.3017499039999998]
+      weight: 0.03694429301131308
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.7830557069886868
+      position: [2.358692414000001, 7.364085, -1.3017499039999998]
+      weight: 0.03694429301131308
   - Cs: 10
     Te: 3
     element: Cs
@@ -96,16 +96,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.598637609569076
-      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
-      weight: 0.2813623904309237
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9415537240720857
-      position: [2.358692414, 1.472817, -1.3017499039999998]
-      weight: -0.12155372407208587
+      site_index: 0
+      distance: 4.440793142957318
+      position: [3.3518260619999998, -1.472817, 0.8542733745]
+      weight: 0.4392068570426817
     - element: Cs
       kind:
       site_index: 0
@@ -114,40 +108,10 @@ ref:
       weight: 0.4392068570426817
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
-      weight: -0.1465640719674388
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.026564071967439
-      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
-      weight: -0.1465640719674388
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, -1.472817, 1.301749904]
-      weight: -0.17406936137114037
-    - element: Cs
-      kind:
-      site_index: 0
-      distance: 4.440793142957318
-      position: [3.3518260619999998, -1.472817, 0.8542733745]
-      weight: 0.4392068570426817
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.99406936137114
-      position: [-2.358692414, 4.418451, 1.301749904]
-      weight: -0.17406936137114037
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.785799937495917
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 0.09420006250408264
+      site_index: 2
+      distance: 5.092829270783993
+      position: [-4.53594695, 1.472817, 3.789022042]
+      weight: -0.21282927078399272
     - element: Cs
       kind:
       site_index: 2
@@ -158,20 +122,56 @@ ref:
       kind:
       site_index: 3
       distance: 4.4822853026157565
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
+      position: [-1.4228549380000002, -1.472817, 4.962921509]
       weight: 0.39771469738424337
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 5.092829270783993
-      position: [-4.53594695, 1.472817, 3.789022042]
-      weight: -0.21282927078399272
     - element: Cs
       kind:
       site_index: 3
       distance: 4.4822853026157565
-      position: [-1.4228549380000002, -1.472817, 4.962921509]
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
       weight: 0.39771469738424337
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.785799937495917
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 0.09420006250408264
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, -1.472817, -2.0223614580000002]
+      weight: -0.1465640719674388
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.026564071967439
+      position: [-0.23873405000000023, 4.418451, -2.0223614580000002]
+      weight: -0.1465640719674388
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.598637609569076
+      position: [-3.3518260619999998, 1.472817, -0.8484619909999994]
+      weight: 0.2813623904309237
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, -1.472817, 1.301749904]
+      weight: -0.17406936137114037
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.99406936137114
+      position: [-2.358692414, 4.418451, 1.301749904]
+      weight: -0.17406936137114037
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9415537240720857
+      position: [2.358692414, 1.472817, -1.3017499039999998]
+      weight: -0.12155372407208587
   - Cs: 10
     Te: 3
     element: Cs
@@ -186,8 +186,32 @@ ref:
       kind:
       site_index: 0
       distance: 4.477765890306448
+      position: [3.3518260619999998, -1.472817, 0.8542733745]
+      weight: 0.402234109693552
+    - element: Cs
+      kind:
+      site_index: 0
+      distance: 4.477765890306448
       position: [3.3518260619999998, 4.418451, 0.8542733745]
       weight: 0.402234109693552
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 5.089246884904623
+      position: [0.24064392240000002, 1.472817, 2.022361458]
+      weight: -0.20924688490462273
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 5.092829270783991
+      position: [9.790005922399999, 1.472817, 2.022361458]
+      weight: -0.21282927078399094
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.443663071808785
+      position: [8.126507062, -1.472817, 4.962921509]
+      weight: 0.4363369281912153
     - element: Cs
       kind:
       site_index: 3
@@ -196,58 +220,10 @@ ref:
       weight: 0.4363369281912153
     - element: Cs
       kind:
-      site_index: 0
-      distance: 4.477765890306448
-      position: [3.3518260619999998, -1.472817, 0.8542733745]
-      weight: 0.402234109693552
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.78627208103842
-      position: [6.197535938000001, 1.472817, -0.8484619909999994]
-      weight: 0.09372791896158006
-    - element: Cs
-      kind:
       site_index: 4
       distance: 4.597145765930607
       position: [1.422854938, 1.472817, 6.659845491]
       weight: 0.2828542340693927
-    - element: Cs
-      kind:
-      site_index: 1
-      distance: 5.089246884904623
-      position: [0.24064392240000002, 1.472817, 2.022361458]
-      weight: -0.20924688490462273
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: -0.17282668163819048
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.443663071808785
-      position: [8.126507062, -1.472817, 4.962921509]
-      weight: 0.4363369281912153
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.9928266816381903
-      position: [2.415988586, -1.472817, 4.509633596]
-      weight: -0.17282668163819048
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.942580349475588
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: -0.12258034947558816
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.026382289051357
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: -0.14638228905135708
     - element: Cs
       kind:
       site_index: 5
@@ -256,10 +232,34 @@ ref:
       weight: -0.14638228905135708
     - element: Cs
       kind:
-      site_index: 1
-      distance: 5.092829270783991
-      position: [9.790005922399999, 1.472817, 2.022361458]
-      weight: -0.21282927078399094
+      site_index: 5
+      distance: 5.026382289051357
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: -0.14638228905135708
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.78627208103842
+      position: [6.197535938000001, 1.472817, -0.8484619909999994]
+      weight: 0.09372791896158006
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, -1.472817, 4.509633596]
+      weight: -0.17282668163819048
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.9928266816381903
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: -0.17282668163819048
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.942580349475588
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: -0.12258034947558816
   - Cs: 8
     Te: 4
     element: Cs
@@ -270,18 +270,6 @@ ref:
     max_dist: 4.78627208103842
     avg_dist: 4.275488052835503
     neighbours:
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.778884663858415
-      position: [7.190669586, 4.418451, 1.301749904]
-      weight: 0.0411153361415848
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 4.443663071808785
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: 0.4363369281912153
     - element: Cs
       kind:
       site_index: 1
@@ -298,25 +286,25 @@ ref:
       kind:
       site_index: 2
       distance: 4.443663071808785
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: 0.4363369281912153
+    - element: Cs
+      kind:
+      site_index: 2
+      distance: 4.443663071808785
       position: [5.013415050000001, 7.364085, 3.789022042]
       weight: 0.4363369281912153
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.779746724073622
-      position: [7.133373414, 7.364085, 7.113133404]
-      weight: 0.04025327592637762
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.8655128422796174
-      position: [11.965350586000001, 4.418451, 4.509633596]
-      weight: -0.045512842279617605
     - element: Cs
       kind:
       site_index: 4
       distance: 4.433325541961325
       position: [10.972216938, 1.472817, 6.659845491]
+      weight: 0.4466744580386752
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.433325541961325
+      position: [10.972216938, 7.364085, 6.659845491]
       weight: 0.4466744580386752
     - element: Cs
       kind:
@@ -326,21 +314,33 @@ ref:
       weight: 0.2828542340693927
     - element: Cs
       kind:
-      site_index: 4
-      distance: 4.433325541961325
-      position: [10.972216938, 7.364085, 6.659845491]
-      weight: 0.4466744580386752
-    - element: Cs
-      kind:
       site_index: 6
       distance: 4.78627208103842
       position: [9.31062795, 4.418451, 9.600405541999999]
       weight: 0.09372791896158006
     - element: Te
       kind:
+      site_index: 8
+      distance: 3.778884663858415
+      position: [7.190669586, 4.418451, 1.301749904]
+      weight: 0.0411153361415848
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.8655128422796174
+      position: [11.965350586000001, 4.418451, 4.509633596]
+      weight: -0.045512842279617605
+    - element: Te
+      kind:
       site_index: 10
       distance: 3.779746724073622
       position: [7.133373414, 1.472817, 7.113133404]
+      weight: 0.04025327592637762
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.779746724073622
+      position: [7.133373414, 7.364085, 7.113133404]
       weight: 0.04025327592637762
   - Cs: 8
     Te: 4
@@ -352,54 +352,6 @@ ref:
     max_dist: 4.785799937495917
     avg_dist: 4.275330631696741
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.865512842279616
-      position: [-2.415988586, 1.472817, 7.113133404]
-      weight: -0.04551284227961627
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.4363369281912144
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 4.4436630718087855
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-      weight: 0.4363369281912144
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
-      weight: 0.39842315244556037
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, -1.472817, 4.509633596]
-      weight: 0.04025327592637762
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 4.433325541961324
-      position: [-1.4228549380000002, 4.418451, 4.962921509]
-      weight: 0.4466744580386761
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 4.4815768475544395
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-      weight: 0.39842315244556037
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.779746724073622
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: 0.04025327592637762
     - element: Cs
       kind:
       site_index: 1
@@ -412,18 +364,66 @@ ref:
       distance: 4.597145765930607
       position: [5.013415050000001, 1.472817, 3.789022042]
       weight: 0.2828542340693927
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.778884663858416
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: 0.041115336141583914
     - element: Cs
       kind:
       site_index: 3
       distance: 4.433325541961324
       position: [-1.4228549380000002, -1.472817, 4.962921509]
       weight: 0.4466744580386761
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.433325541961324
+      position: [-1.4228549380000002, 4.418451, 4.962921509]
+      weight: 0.4466744580386761
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 0.4363369281912144
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 4.4436630718087855
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.4363369281912144
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, -1.472817, 9.600405541999999]
+      weight: 0.39842315244556037
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 4.4815768475544395
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+      weight: 0.39842315244556037
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, -1.472817, 4.509633596]
+      weight: 0.04025327592637762
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.779746724073622
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: 0.04025327592637762
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.865512842279616
+      position: [-2.415988586, 1.472817, 7.113133404]
+      weight: -0.04551284227961627
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.778884663858416
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: 0.041115336141583914
   - Cs: 10
     Te: 3
     element: Cs
@@ -436,70 +436,34 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.597145765930607
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 0.2828542340693927
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 1.472817, 10.774305009]
-      weight: 0.3984231524455595
-    - element: Cs
-      kind:
-      site_index: 6
-      distance: 5.091038034705715
-      position: [9.31062795, 4.418451, 9.600405541999999]
-      weight: -0.21103803470571503
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4436630718087855
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 0.4363369281912144
-    - element: Te
-      kind:
-      site_index: 9
-      distance: 3.942580349475589
-      position: [2.415988586, 4.418451, 4.509633596]
-      weight: -0.12258034947558905
-    - element: Cs
-      kind:
-      site_index: 2
-      distance: 5.026382289051357
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: -0.14638228905135708
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: -0.17282668163819048
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.791903025133938
       position: [3.3518260619999998, 4.418451, 12.477040374499998]
       weight: 0.08809697486606183
     - element: Cs
       kind:
-      site_index: 6
-      distance: 5.091038034705714
-      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
-      weight: -0.21103803470571414
+      site_index: 2
+      distance: 5.026382289051357
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: -0.14638228905135708
     - element: Cs
       kind:
-      site_index: 7
-      distance: 4.48157684755444
-      position: [6.197535938000001, 7.364085, 10.774305009]
-      weight: 0.3984231524455595
-    - element: Te
+      site_index: 2
+      distance: 5.026382289051357
+      position: [5.013415050000001, 7.364085, 3.789022042]
+      weight: -0.14638228905135708
+    - element: Cs
       kind:
-      site_index: 10
-      distance: 3.9928266816381903
-      position: [7.133373414, 7.364085, 7.113133404]
-      weight: -0.17282668163819048
+      site_index: 3
+      distance: 4.597145765930607
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 0.2828542340693927
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4436630718087855
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 0.4363369281912144
     - element: Cs
       kind:
       site_index: 4
@@ -508,10 +472,46 @@ ref:
       weight: 0.4363369281912144
     - element: Cs
       kind:
-      site_index: 2
-      distance: 5.026382289051357
-      position: [5.013415050000001, 7.364085, 3.789022042]
-      weight: -0.14638228905135708
+      site_index: 6
+      distance: 5.091038034705714
+      position: [-0.23873405000000023, 4.418451, 9.600405541999999]
+      weight: -0.21103803470571414
+    - element: Cs
+      kind:
+      site_index: 6
+      distance: 5.091038034705715
+      position: [9.31062795, 4.418451, 9.600405541999999]
+      weight: -0.21103803470571503
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 1.472817, 10.774305009]
+      weight: 0.3984231524455595
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.48157684755444
+      position: [6.197535938000001, 7.364085, 10.774305009]
+      weight: 0.3984231524455595
+    - element: Te
+      kind:
+      site_index: 9
+      distance: 3.942580349475589
+      position: [2.415988586, 4.418451, 4.509633596]
+      weight: -0.12258034947558905
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: -0.17282668163819048
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.9928266816381903
+      position: [7.133373414, 7.364085, 7.113133404]
+      weight: -0.17282668163819048
   - Cs: 10
     Te: 3
     element: Cs
@@ -524,70 +524,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 4.78627208103842
-      position: [8.126507062, 4.418451, 4.962921509000002]
-      weight: 0.09372791896158006
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 1.472817, 10.774305009000003]
-      weight: 0.4363369281912135
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [14.085308950000002, 4.418451, 7.833744958000002]
-      weight: -0.21103803470571503
-    - element: Cs
-      kind:
-      site_index: 4
-      distance: 4.4815768475544395
-      position: [10.972216938, 7.364085, 6.659845491000001]
-      weight: 0.39842315244556037
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 7.364085, 10.321017096000002]
-      weight: -0.1728266816381887
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.9928266816381885
-      position: [11.908054413999999, 1.472817, 10.321017096000002]
-      weight: -0.1728266816381887
-    - element: Cs
-      kind:
       site_index: 0
       distance: 4.600777094952303
       position: [12.901188062000001, 4.418451, 12.4770403745]
       weight: 0.2792229050476971
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 5.091038034705715
-      position: [4.53594695, 4.418451, 7.833744958000002]
-      weight: -0.21103803470571503
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.9425803494755898
-      position: [7.190669586, 4.418451, 12.924516904000003]
-      weight: -0.12258034947558993
-    - element: Cs
-      kind:
-      site_index: 1
-      distance: 5.026564071967438
-      position: [9.790005922399999, 7.364085, 13.645128458]
-      weight: -0.14656407196743793
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 4.443663071808786
-      position: [6.197535938000001, 7.364085, 10.774305009000003]
-      weight: 0.4363369281912135
     - element: Cs
       kind:
       site_index: 1
@@ -596,10 +536,70 @@ ref:
       weight: -0.14656407196743793
     - element: Cs
       kind:
+      site_index: 1
+      distance: 5.026564071967438
+      position: [9.790005922399999, 7.364085, 13.645128458]
+      weight: -0.14656407196743793
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 4.78627208103842
+      position: [8.126507062, 4.418451, 4.962921509000002]
+      weight: 0.09372791896158006
+    - element: Cs
+      kind:
       site_index: 4
       distance: 4.4815768475544395
       position: [10.972216938, 1.472817, 6.659845491000001]
       weight: 0.39842315244556037
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 4.4815768475544395
+      position: [10.972216938, 7.364085, 6.659845491000001]
+      weight: 0.39842315244556037
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [4.53594695, 4.418451, 7.833744958000002]
+      weight: -0.21103803470571503
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 5.091038034705715
+      position: [14.085308950000002, 4.418451, 7.833744958000002]
+      weight: -0.21103803470571503
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 1.472817, 10.774305009000003]
+      weight: 0.4363369281912135
+    - element: Cs
+      kind:
+      site_index: 7
+      distance: 4.443663071808786
+      position: [6.197535938000001, 7.364085, 10.774305009000003]
+      weight: 0.4363369281912135
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.9425803494755898
+      position: [7.190669586, 4.418451, 12.924516904000003]
+      weight: -0.12258034947558993
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 1.472817, 10.321017096000002]
+      weight: -0.1728266816381887
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.9928266816381885
+      position: [11.908054413999999, 7.364085, 10.321017096000002]
+      weight: -0.1728266816381887
   - Cs: 8
     Te: 4
     element: Cs
@@ -610,30 +610,24 @@ ref:
     max_dist: 4.78627208103842
     avg_dist: 4.2758655716662615
     neighbours:
-    - element: Te
-      kind:
-      site_index: 10
-      distance: 3.778884663858416
-      position: [7.133373414, 1.472817, 7.113133404]
-      weight: 0.041115336141583914
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: 0.3984231524455595
-    - element: Te
-      kind:
-      site_index: 11
-      distance: 3.8655128422796166
-      position: [2.358692414, 1.472817, 10.321017096]
-      weight: -0.045512842279616716
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, -1.472817, 12.477040374499998]
+      weight: 0.4444468118120426
     - element: Cs
       kind:
-      site_index: 5
-      distance: 4.48157684755444
-      position: [4.53594695, -1.472817, 7.8337449580000005]
-      weight: 0.3984231524455595
+      site_index: 0
+      distance: 4.435553188187957
+      position: [3.3518260619999998, 4.418451, 12.477040374499998]
+      weight: 0.4444468118120426
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 4.5986376095690735
+      position: [9.790005922399999, 1.472817, 13.645128457999999]
+      weight: 0.28136239043092637
     - element: Cs
       kind:
       site_index: 2
@@ -642,28 +636,16 @@ ref:
       weight: 0.09372791896158006
     - element: Cs
       kind:
-      site_index: 1
-      distance: 4.5986376095690735
-      position: [9.790005922399999, 1.472817, 13.645128457999999]
-      weight: 0.28136239043092637
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, -1.472817, 12.924516904]
-      weight: 0.04025327592637762
-    - element: Te
-      kind:
-      site_index: 8
-      distance: 3.779746724073622
-      position: [7.190669586, 4.418451, 12.924516904]
-      weight: 0.04025327592637762
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, -1.472817, 7.8337449580000005]
+      weight: 0.3984231524455595
     - element: Cs
       kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, 4.418451, 12.477040374499998]
-      weight: 0.4444468118120426
+      site_index: 5
+      distance: 4.48157684755444
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: 0.3984231524455595
     - element: Cs
       kind:
       site_index: 6
@@ -676,12 +658,30 @@ ref:
       distance: 4.443663071808786
       position: [9.31062795, 4.418451, 9.600405541999999]
       weight: 0.4363369281912135
-    - element: Cs
+    - element: Te
       kind:
-      site_index: 0
-      distance: 4.435553188187957
-      position: [3.3518260619999998, -1.472817, 12.477040374499998]
-      weight: 0.4444468118120426
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, -1.472817, 12.924516904]
+      weight: 0.04025327592637762
+    - element: Te
+      kind:
+      site_index: 8
+      distance: 3.779746724073622
+      position: [7.190669586, 4.418451, 12.924516904]
+      weight: 0.04025327592637762
+    - element: Te
+      kind:
+      site_index: 10
+      distance: 3.778884663858416
+      position: [7.133373414, 1.472817, 7.113133404]
+      weight: 0.041115336141583914
+    - element: Te
+      kind:
+      site_index: 11
+      distance: 3.8655128422796166
+      position: [2.358692414, 1.472817, 10.321017096]
+      weight: -0.045512842279616716
   - Cs: 7
     Te: 0
     element: Te
@@ -694,16 +694,28 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 1
-      distance: 3.9940693613711393
-      position: [9.790005922399999, 7.364085, 2.022361458]
-      weight: -0.17406936137113949
+      site_index: 0
+      distance: 3.864835681657127
+      position: [3.3518260619999998, 4.418451, 0.8542733745]
+      weight: -0.04483568165712715
     - element: Cs
       kind:
       site_index: 1
       distance: 3.9940693613711393
       position: [9.790005922399999, 1.472817, 2.022361458]
       weight: -0.17406936137113949
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 3.9940693613711393
+      position: [9.790005922399999, 7.364085, 2.022361458]
+      weight: -0.17406936137113949
+    - element: Cs
+      kind:
+      site_index: 3
+      distance: 3.778884663858415
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 0.0411153361415848
     - element: Cs
       kind:
       site_index: 6
@@ -714,26 +726,14 @@ ref:
       kind:
       site_index: 7
       distance: 3.7797467240736218
-      position: [6.197535938000001, 7.364085, -0.8484619909999994]
-      weight: 0.04025327592637806
-    - element: Cs
-      kind:
-      site_index: 3
-      distance: 3.778884663858415
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 0.0411153361415848
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 3.7797467240736218
       position: [6.197535938000001, 1.472817, -0.8484619909999994]
       weight: 0.04025327592637806
     - element: Cs
       kind:
-      site_index: 0
-      distance: 3.864835681657127
-      position: [3.3518260619999998, 4.418451, 0.8542733745]
-      weight: -0.04483568165712715
+      site_index: 7
+      distance: 3.7797467240736218
+      position: [6.197535938000001, 7.364085, -0.8484619909999994]
+      weight: 0.04025327592637806
   - Cs: 7
     Te: 0
     element: Te
@@ -752,18 +752,6 @@ ref:
       weight: 0.04674541934809584
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.779746724073622
-      position: [1.422854938, 1.472817, 6.659845491]
-      weight: 0.04025327592637762
-    - element: Cs
-      kind:
-      site_index: 5
-      distance: 3.942580349475589
-      position: [4.53594695, 4.418451, 7.8337449580000005]
-      weight: -0.12258034947558905
-    - element: Cs
-      kind:
       site_index: 2
       distance: 3.9928266816381903
       position: [5.013415050000001, 1.472817, 3.789022042]
@@ -784,8 +772,20 @@ ref:
       kind:
       site_index: 4
       distance: 3.779746724073622
+      position: [1.422854938, 1.472817, 6.659845491]
+      weight: 0.04025327592637762
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.779746724073622
       position: [1.422854938, 7.364085, 6.659845491]
       weight: 0.04025327592637762
+    - element: Cs
+      kind:
+      site_index: 5
+      distance: 3.942580349475589
+      position: [4.53594695, 4.418451, 7.8337449580000005]
+      weight: -0.12258034947558905
   - Cs: 7
     Te: 0
     element: Te
@@ -798,16 +798,10 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 3
-      distance: 3.779746724073622
-      position: [8.126507062, 4.418451, 4.962921509]
-      weight: 0.04025327592637762
-    - element: Cs
-      kind:
-      site_index: 7
-      distance: 3.778884663858416
-      position: [6.197535938000001, 1.472817, 10.774305009]
-      weight: 0.041115336141583914
+      site_index: 2
+      distance: 3.942580349475588
+      position: [5.013415050000001, 1.472817, 3.789022042]
+      weight: -0.12258034947558816
     - element: Cs
       kind:
       site_index: 3
@@ -816,10 +810,16 @@ ref:
       weight: 0.04025327592637762
     - element: Cs
       kind:
-      site_index: 2
-      distance: 3.942580349475588
-      position: [5.013415050000001, 1.472817, 3.789022042]
-      weight: -0.12258034947558816
+      site_index: 3
+      distance: 3.779746724073622
+      position: [8.126507062, 4.418451, 4.962921509]
+      weight: 0.04025327592637762
+    - element: Cs
+      kind:
+      site_index: 4
+      distance: 3.8655128422796166
+      position: [10.972216938, 1.472817, 6.659845491]
+      weight: -0.045512842279616716
     - element: Cs
       kind:
       site_index: 5
@@ -834,10 +834,10 @@ ref:
       weight: -0.17282668163819048
     - element: Cs
       kind:
-      site_index: 4
-      distance: 3.8655128422796166
-      position: [10.972216938, 1.472817, 6.659845491]
-      weight: -0.045512842279616716
+      site_index: 7
+      distance: 3.778884663858416
+      position: [6.197535938000001, 1.472817, 10.774305009]
+      weight: 0.041115336141583914
   - Cs: 7
     Te: 0
     element: Te
@@ -850,16 +850,22 @@ ref:
     neighbours:
     - element: Cs
       kind:
-      site_index: 7
-      distance: 3.865512842279617
-      position: [6.1975359380000015, 1.472817, 10.774305009]
-      weight: -0.04551284227961716
-    - element: Cs
-      kind:
       site_index: 0
       distance: 3.783055706988686
       position: [3.351826062, -1.472817, 12.477040374499998]
       weight: 0.03694429301131397
+    - element: Cs
+      kind:
+      site_index: 0
+      distance: 3.783055706988686
+      position: [3.351826062, 4.418451, 12.477040374499998]
+      weight: 0.03694429301131397
+    - element: Cs
+      kind:
+      site_index: 1
+      distance: 3.9415537240720844
+      position: [0.24064392240000046, 1.472817, 13.645128457999999]
+      weight: -0.12155372407208453
     - element: Cs
       kind:
       site_index: 4
@@ -874,72 +880,67 @@ ref:
       weight: -0.17282668163819048
     - element: Cs
       kind:
-      site_index: 0
-      distance: 3.783055706988686
-      position: [3.351826062, 4.418451, 12.477040374499998]
-      weight: 0.03694429301131397
-    - element: Cs
-      kind:
       site_index: 6
       distance: 3.9928266816381903
       position: [-0.23873404999999978, 4.418451, 9.600405541999999]
       weight: -0.17282668163819048
     - element: Cs
       kind:
-      site_index: 1
-      distance: 3.9415537240720844
-      position: [0.24064392240000046, 1.472817, 13.645128457999999]
-      weight: -0.12155372407208453
+      site_index: 7
+      distance: 3.865512842279617
+      position: [6.1975359380000015, 1.472817, 10.774305009]
+      weight: -0.04551284227961716
   nrs_avg:
-    &id001 [Cs, Cs]: 9
-    &id002 [Cs, Te]: 3.5
-    &id003 [Te, Cs]: 7
-    &id004 [Te, Te]: 0
+    [Cs, Cs]: 9
+    [Cs, Te]: 3.5
+    [Te, Cs]: 7
+    [Te, Te]: 0
   nrs_stdev:
-    *id001 : 1.0690449676496976
-    *id002 : 0.5345224838248488
-    *id003 : 0.0
-    *id004 : 0.0
+    [Cs, Cs]: 1.0690449676496976
+    [Cs, Te]: 0.5345224838248488
+    [Te, Cs]: 0.0
+    [Te, Te]: 0.0
   nrs_max:
-    *id001 : 10
-    *id002 : 4
-    *id003 : 7
-    *id004 : 0
+    [Cs, Cs]: 10
+    [Cs, Te]: 4
+    [Te, Cs]: 7
+    [Te, Te]: 0
   nrs_min:
-    *id001 : 8
-    *id002 : 3
-    *id003 : 7
-    *id004 : 0
+    [Cs, Cs]: 8
+    [Cs, Te]: 3
+    [Te, Cs]: 7
+    [Te, Te]: 0
   distance_avg:
-    &id005 [Cs, Te]: 3.876081004436161
-    &id006 [Cs, Cs]: 4.642825840593194
-    &id007 [Te, Cs]: 3.876081004436161
+    [Cs, Te]: 3.876081004436161
+    [Cs, Cs]: 4.642825840593194
+    [Te, Cs]: 3.876081004436161
   distance_stdev:
-    *id005 : 0.09419018141115895
-    *id006 : 0.24822823441566136
-    *id007 : 0.09419018141115902
+    [Cs, Te]: 0.09419018141115895
+    [Cs, Cs]: 0.24822823441566136
+    [Te, Cs]: 0.09419018141115902
   distance_max:
-    *id005 : 3.99406936137114
-    *id006 : 5.092829270783992
-    *id007 : 3.9940693613711407
+    [Cs, Te]: 3.99406936137114
+    [Cs, Cs]: 5.092829270783992
+    [Te, Cs]: 3.9940693613711407
   distance_min:
-    *id005 : 3.7732545806519044
-    *id006 : 4.433325541961324
-    *id007 : 3.7732545806519044
-  weight_avg: 
-    *id005 : -0.056081004436161104 
-    *id006 : 0.2371741594068053 
-    *id007 : -0.056081004436160896
-  weight_stdev: 
-    *id005 : 0.09419018141115895
-    *id006 : 0.24822823441566136
-    *id007 : 0.09419018141115902
-  weight_max: 
-    *id005 : 0.046745419348095396
-    *id006 : 0.4466744580386761
-    *id007 : 0.046745419348095396
-  weight_min: 
-    *id005 : -0.17406936137114037
-    *id006 : -0.21282927078399183
-    *id007 : -0.17406936137114082
-parameters: {r_max: 5.0, method: voronoi, voronoi_weight_type: covalent_atomic_radius, voronoi_weight_threshold: -0.25}
+    [Cs, Te]: 3.7732545806519044
+    [Cs, Cs]: 4.433325541961324
+    [Te, Cs]: 3.7732545806519044
+  weight_avg:
+    [Cs, Te]: -0.056081004436161104
+    [Cs, Cs]: 0.2371741594068053
+    [Te, Cs]: -0.056081004436160896
+  weight_stdev:
+    [Cs, Te]: 0.09419018141115895
+    [Cs, Cs]: 0.24822823441566136
+    [Te, Cs]: 0.09419018141115902
+  weight_max:
+    [Cs, Te]: 0.046745419348095396
+    [Cs, Cs]: 0.4466744580386761
+    [Te, Cs]: 0.046745419348095396
+  weight_min:
+    [Cs, Te]: -0.17406936137114037
+    [Cs, Cs]: -0.21282927078399183
+    [Te, Cs]: -0.17406936137114082
+parameters: {r_max: 5.0, method: voronoi, voronoi_weight_type: covalent_atomic_radius,
+  voronoi_weight_threshold: -0.25}

--- a/tests/strct/coordination/GaAs_216_conv_okeeffe.yaml
+++ b/tests/strct/coordination/GaAs_216_conv_okeeffe.yaml
@@ -20,10 +20,10 @@ ref:
       weight: 0.9999999999999996
     - element: As
       kind:
-      site_index: 7
+      site_index: 5
       distance: 3.5212592917875276
-      position: [-2.033, 2.033, 2.033]
-      weight: 1.0
+      position: [2.033, 2.033, -2.033]
+      weight: 0.9999999999999997
     - element: As
       kind:
       site_index: 6
@@ -32,10 +32,10 @@ ref:
       weight: 1.0
     - element: As
       kind:
-      site_index: 5
+      site_index: 7
       distance: 3.5212592917875276
-      position: [2.033, 2.033, -2.033]
-      weight: 0.9999999999999997
+      position: [-2.033, 2.033, 2.033]
+      weight: 1.0
   - Ga: 0
     As: 4
     element: Ga
@@ -54,10 +54,10 @@ ref:
       weight: 0.9999999999999992
     - element: As
       kind:
-      site_index: 7
-      distance: 3.521259291787527
-      position: [-2.033, 10.165000000000001, 2.033]
-      weight: 1.0
+      site_index: 5
+      distance: 3.5212592917875276
+      position: [2.033, 10.165000000000001, 6.099]
+      weight: 0.9999999999999997
     - element: As
       kind:
       site_index: 6
@@ -66,10 +66,10 @@ ref:
       weight: 0.9999999999999993
     - element: As
       kind:
-      site_index: 5
-      distance: 3.5212592917875276
-      position: [2.033, 10.165000000000001, 6.099]
-      weight: 0.9999999999999997
+      site_index: 7
+      distance: 3.521259291787527
+      position: [-2.033, 10.165000000000001, 2.033]
+      weight: 1.0
   - Ga: 0
     As: 4
     element: Ga
@@ -82,12 +82,6 @@ ref:
     neighbours:
     - element: As
       kind:
-      site_index: 6
-      distance: 3.5212592917875276
-      position: [2.033, -2.033, 2.033]
-      weight: 0.999999999999999
-    - element: As
-      kind:
       site_index: 4
       distance: 3.521259291787528
       position: [6.099, -2.033, 6.099]
@@ -98,6 +92,12 @@ ref:
       distance: 3.5212592917875276
       position: [2.033, 2.033, 6.099]
       weight: 0.9999999999999992
+    - element: As
+      kind:
+      site_index: 6
+      distance: 3.5212592917875276
+      position: [2.033, -2.033, 2.033]
+      weight: 0.999999999999999
     - element: As
       kind:
       site_index: 7
@@ -116,6 +116,18 @@ ref:
     neighbours:
     - element: As
       kind:
+      site_index: 4
+      distance: 3.521259291787528
+      position: [6.099, 6.099, -2.033]
+      weight: 0.9999999999999993
+    - element: As
+      kind:
+      site_index: 5
+      distance: 3.5212592917875276
+      position: [2.033, 2.033, -2.033]
+      weight: 1.0
+    - element: As
+      kind:
       site_index: 6
       distance: 3.5212592917875276
       position: [2.033, 6.099, 2.033]
@@ -126,18 +138,6 @@ ref:
       distance: 3.5212592917875276
       position: [6.099, 2.033, 2.033]
       weight: 0.9999999999999997
-    - element: As
-      kind:
-      site_index: 5
-      distance: 3.5212592917875276
-      position: [2.033, 2.033, -2.033]
-      weight: 1.0
-    - element: As
-      kind:
-      site_index: 4
-      distance: 3.521259291787528
-      position: [6.099, 6.099, -2.033]
-      weight: 0.9999999999999993
   - Ga: 4
     As: 0
     element: As
@@ -150,28 +150,28 @@ ref:
     neighbours:
     - element: Ga
       kind:
-      site_index: 2
-      distance: 3.5212592917875276
-      position: [4.066, 8.132, 4.066]
-      weight: 0.9999999999999997
-    - element: Ga
-      kind:
       site_index: 0
       distance: 3.5212592917875267
       position: [8.132, 8.132, 8.132]
       weight: 1.0
     - element: Ga
       kind:
-      site_index: 3
-      distance: 3.5212592917875276
-      position: [4.066, 4.066, 8.132]
-      weight: 0.9999999999999997
-    - element: Ga
-      kind:
       site_index: 1
       distance: 3.5212592917875276
       position: [8.132, 4.066, 4.066]
       weight: 1.0
+    - element: Ga
+      kind:
+      site_index: 2
+      distance: 3.5212592917875276
+      position: [4.066, 8.132, 4.066]
+      weight: 0.9999999999999997
+    - element: Ga
+      kind:
+      site_index: 3
+      distance: 3.5212592917875276
+      position: [4.066, 4.066, 8.132]
+      weight: 0.9999999999999997
   - Ga: 4
     As: 0
     element: As
@@ -184,6 +184,12 @@ ref:
     neighbours:
     - element: Ga
       kind:
+      site_index: 0
+      distance: 3.521259291787527
+      position: [0.0, 0.0, 8.132]
+      weight: 0.9999999999999997
+    - element: Ga
+      kind:
       site_index: 1
       distance: 3.5212592917875276
       position: [0.0, 4.066, 4.066]
@@ -194,12 +200,6 @@ ref:
       distance: 3.5212592917875276
       position: [4.066, 0.0, 4.066]
       weight: 0.9999999999999999
-    - element: Ga
-      kind:
-      site_index: 0
-      distance: 3.521259291787527
-      position: [0.0, 0.0, 8.132]
-      weight: 0.9999999999999997
     - element: Ga
       kind:
       site_index: 3
@@ -252,12 +252,6 @@ ref:
     neighbours:
     - element: Ga
       kind:
-      site_index: 2
-      distance: 3.5212592917875276
-      position: [4.066, 0.0, 4.066]
-      weight: 0.9999999999999992
-    - element: Ga
-      kind:
       site_index: 0
       distance: 3.521259291787527
       position: [8.132, 0.0, 0.0]
@@ -270,52 +264,58 @@ ref:
       weight: 0.9999999999999997
     - element: Ga
       kind:
+      site_index: 2
+      distance: 3.5212592917875276
+      position: [4.066, 0.0, 4.066]
+      weight: 0.9999999999999992
+    - element: Ga
+      kind:
       site_index: 3
       distance: 3.5212592917875276
       position: [4.066, 4.066, 0.0]
       weight: 0.9999999999999993
   nrs_avg:
-    &id001 [Ga, Ga]: 0
-    &id002 [Ga, As]: 4
-    &id003 [As, Ga]: 4
-    &id004 [As, As]: 0
+    [Ga, Ga]: 0
+    [Ga, As]: 4
+    [As, Ga]: 4
+    [As, As]: 0
   nrs_stdev:
-    *id001 : 0.0
-    *id002 : 0.0
-    *id003 : 0.0
-    *id004 : 0.0
+    [Ga, Ga]: 0.0
+    [Ga, As]: 0.0
+    [As, Ga]: 0.0
+    [As, As]: 0.0
   nrs_max:
-    *id001 : 0
-    *id002 : 4
-    *id003 : 4
-    *id004 : 0
+    [Ga, Ga]: 0
+    [Ga, As]: 4
+    [As, Ga]: 4
+    [As, As]: 0
   nrs_min:
-    *id001 : 0
-    *id002 : 4
-    *id003 : 4
-    *id004 : 0
+    [Ga, Ga]: 0
+    [Ga, As]: 4
+    [As, Ga]: 4
+    [As, As]: 0
   distance_avg:
-    &id005 [Ga, As]: 3.521259291787528
-    &id006 [As, Ga]: 3.5212592917875276
+    [Ga, As]: 3.521259291787528
+    [As, Ga]: 3.5212592917875276
   distance_stdev:
-    *id005 : 8.426000324584082e-16
-    *id006 : 1.056755042076211e-15
+    [Ga, As]: 8.426000324584082e-16
+    [As, Ga]: 1.056755042076211e-15
   distance_max:
-    *id005 : 3.5212592917875285
-    *id006 : 3.5212592917875285
+    [Ga, As]: 3.5212592917875285
+    [As, Ga]: 3.5212592917875285
   distance_min:
-    *id005 : 3.521259291787526
-    *id006 : 3.5212592917875254
+    [Ga, As]: 3.521259291787526
+    [As, Ga]: 3.5212592917875254
   weight_avg:
-    *id005 : 1.0
-    *id006 : 1.0
+    [Ga, As]: 1.0
+    [As, Ga]: 1.0
   weight_stdev:
-    *id005 : 0.0
-    *id006 : 0.0
+    [Ga, As]: 0.0
+    [As, Ga]: 0.0
   weight_max:
-    *id005 : 1.0
-    *id006 : 1.0
+    [Ga, As]: 1.0
+    [As, Ga]: 1.0
   weight_min:
-    *id005 : 1.0
-    *id006 : 1.0
+    [Ga, As]: 1.0
+    [As, Ga]: 1.0
 parameters: {r_max: 5.0, method: okeeffe, okeeffe_weight_threshold: 0.5}


### PR DESCRIPTION
The order of the neighboring sites obtained from the Voronoi analysis is fixed to a certain sorting in this commit. The background of this change is that the unsorted results caused some problems with the tests.