### PR TITLE
Addition of `use_openapi` in the doc-string of `import_from_mp`

### DIFF
--- a/aim2dat/strct/structure_importer.py
+++ b/aim2dat/strct/structure_importer.py
@@ -187,7 +187,7 @@ class StructureImporter(ConstraintsMixin):
             The initial or final structure can be queried by setting this attribute
             to ``initial`` or ``final``, respectively. The default setting is ``initial``.
         use_openapi : bool (optional)
-            Whether to use the openapi interface of Materials Project. If set to ``False`` the 
+            Whether to use the openapi interface of Materials Project. If set to ``False`` the
             legacy interface is used. The default value is ``False``.
         """
         if not isinstance(api_key, str):

--- a/aim2dat/strct/structure_importer.py
+++ b/aim2dat/strct/structure_importer.py
@@ -183,9 +183,11 @@ class StructureImporter(ConstraintsMixin):
             of strings (e.g. ``['el_bandstructure', 'el_dos']`` to obtain the electronic band
             structure and the electronic density of states). The default value is ``[]``.
         structure_type : str (optional)
-            Materials project includes the initial and final (relaxed) stucture in the database.
-            The intial or final structure can be queried by setting this attribute
+            Materials project includes the initial and final (relaxed) structure in the database.
+            The initial or final structure can be queried by setting this attribute
             to ``initial`` or ``final``, respectively. The default setting is ``initial``.
+        use_openapi : bool (optional)
+            Whether to use openapi as provider. The default value is ``False``.
         """
         if not isinstance(api_key, str):
             raise TypeError(

--- a/aim2dat/strct/structure_importer.py
+++ b/aim2dat/strct/structure_importer.py
@@ -187,7 +187,8 @@ class StructureImporter(ConstraintsMixin):
             The initial or final structure can be queried by setting this attribute
             to ``initial`` or ``final``, respectively. The default setting is ``initial``.
         use_openapi : bool (optional)
-            Whether to use openapi as provider. The default value is ``False``.
+            Whether to use the openapi interface of Materials Project. If set to ``False`` the 
+            legacy interface is used. The default value is ``False``.
         """
         if not isinstance(api_key, str):
             raise TypeError(


### PR DESCRIPTION
- `use_openapi` parameter is now added in the doc-strings 
- `import_from_mp` is already on the 'Interfaces to online databases and random crystal generation' page. 

If necessary, we can provide information also regarding openapi, but the doc-string already explains its use.

Closes #41 