### PR TITLE
Speed-up identification of duplicate structures.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Version 0.2.0
 * Support CP2K versions 2022.1-2024.1 (PR #51 <https://github.com/aim2dat/aim2dat/pull/51>`_).
 * The newly implemented``strct.ext_manipulation.add_structure_random`` adds a guest structure at a random position and orientation (PR #53 <https://github.com/aim2dat/aim2dat/pull/53>`_).
 * ``strct.Structure.from_file`` interfaces functions from the ``io`` sub-package via the internal ``'backend'`` and adds more parameters to control the ``'ase'`` backend (PR #56 <https://github.com/aim2dat/aim2dat/pull/56>`_).
+* The methods to find duplicate structures of ``strct.StructureOperations`` are sped up by comparing the chemical formulas prior to more expensive checks (PR #61 <https://github.com/aim2dat/aim2dat/pull/61>`_)
 
 **Depreciations:**
 

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -48,11 +48,11 @@ def _create_index_combinations(confined, strct_c):
     for idx0 in range(strct_c_len):
         for idx1 in range(min_idx, max_idx):
             if (
-                utils_cf.compare_formulas(
+                idx0 != idx1
+                and (idx1, idx0) not in pairs
+                and utils_cf.compare_formulas(
                     strct_c[idx0].chem_formula, strct_c[idx1].chem_formula, reduce_formulas=True
                 )
-                and idx0 != idx1
-                and (idx1, idx0) not in pairs
             ):
                 pairs.append((idx0, idx1))
     return pairs

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -30,9 +30,12 @@ from aim2dat.strct.strct_coordination import _coordination_compare_sites
 from aim2dat.strct.strct_prdf import _ffingerprint_compare_sites
 from aim2dat.strct.strct_space_groups import determine_space_group
 from aim2dat.strct.strct_prdf import calculate_ffingerprint
+import aim2dat.utils.chem_formula as utils_cf
 
 
-def _create_index_combinations(confined, strct_c_len):
+def _create_index_combinations(confined, strct_c):
+    """Create index combinations for duplicate identification."""
+    strct_c_len = len(strct_c)
     if confined is None:
         return list(itertools.combinations(range(strct_c_len), 2))
     min_idx = confined[0]
@@ -44,7 +47,13 @@ def _create_index_combinations(confined, strct_c_len):
     pairs = []
     for idx0 in range(strct_c_len):
         for idx1 in range(min_idx, max_idx):
-            if idx0 != idx1 and (idx1, idx0) not in pairs:
+            if (
+                utils_cf.compare_formulas(
+                    strct_c[idx0].chem_formula, strct_c[idx1].chem_formula, reduce_formulas=True
+                )
+                and idx0 != idx1
+                and (idx1, idx0) not in pairs
+            ):
                 pairs.append((idx0, idx1))
     return pairs
 
@@ -537,7 +546,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
     ):
         duplicate_pairs = []
         structures2del = []
-        index_comb = _create_index_combinations(confined, len(self.structures))
+        index_comb = _create_index_combinations(confined, self.structures)
 
         if self.n_procs > 1:
             strct_comb = [


### PR DESCRIPTION
This PR adds a comparison of the chemical formula of the two structures before other more expensive checks. This way, only structures with the same stoichiometry are considered as duplicate structures.