### PR TITLE
Fix optimade interface

### DIFF
--- a/aim2dat/ext_interfaces/optimade.py
+++ b/aim2dat/ext_interfaces/optimade.py
@@ -75,14 +75,22 @@ def _return_database_ids(api_version, url, timeout):
     providers = {}
     for prov_id, prov_attr in providers_url.items():
         if prov_attr.get("base_url"):
+            url = prov_attr["base_url"] + f"/v{api_version}/links"
             with requests.Session() as session:
                 response = session.get(
-                    url=prov_attr["base_url"] + f"/v{api_version}/links",
+                    url=url,
                     timeout=timeout,
                 )
                 try:
                     provider_json = response.json()
                 except ValueError:
+                    from warnings import warn
+
+                    warn(
+                        f"Skipping '{prov_id}' database, cannot retrieve information from: {url}.",
+                        UserWarning,
+                        2,
+                    )
                     continue
                 for database in provider_json["data"]:
                     if (

--- a/aim2dat/ext_interfaces/optimade.py
+++ b/aim2dat/ext_interfaces/optimade.py
@@ -80,7 +80,10 @@ def _return_database_ids(api_version, url, timeout):
                     url=prov_attr["base_url"] + f"/v{api_version}/links",
                     timeout=timeout,
                 )
-                provider_json = response.json()
+                try:
+                    provider_json = response.json()
+                except ValueError:
+                    continue
                 for database in provider_json["data"]:
                     if (
                         database["attributes"].get("link_type")

--- a/aim2dat/strct/structure_importer.py
+++ b/aim2dat/strct/structure_importer.py
@@ -275,9 +275,13 @@ class StructureImporter(ConstraintsMixin):
         timeout : float (optional)
             Specifies the time to wait for response from the server. The default value is ``60.0``.
         """
-        print(
+        from warnings import warn
+
+        warn(
             "This method needs to be considered experimental. It seems that the optimade "
-            "interface is unfortunately not yet commonly implemented for all databases."
+            + "interface is unfortunately not yet commonly implemented for all databases.",
+            UserWarning,
+            2,
         )
         download_kwargs = {
             "optimade_url": optimade_url,


### PR DESCRIPTION
So far, the interface was unusable as soon as one of the database interfaces is broken. This PR adds a try/except structure to skip the individual database when the interface is broken and returns a warning. This way, all other databases can still be accessed.