### PR TITLE
Fix slicing in `StructureOperations`

### DIFF
--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -142,7 +142,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
                     stop += len(self)
                 key = range(start, stop)
             for key0 in key:
-                new_sc.append_structure(self.get_structure(key0))
+                new_sc.append_structure(self.structures.get_structure(key0))
             return StructureOperations(new_sc)
         else:
             raise TypeError("key needs to be of type: str, int, slice, tuple or list.")


### PR DESCRIPTION
When using a slice to index `StructureOperations`, an exception is raised as we try to call `self.get_structure`. This is only defined for a `StructureCollection`. Changing it to `self.structures.get_structure` fixes the bug. 