### PR TITLE
Bug fix for importing correct data for each plot label in partial charges plot

### DIFF
--- a/aim2dat/plots/partial_charges.py
+++ b/aim2dat/plots/partial_charges.py
@@ -221,12 +221,12 @@ class PartialChargesPlot(_BasePlot):
                 y_values_height = [
                     all_charge[data]["mean_charge"].get(label)
                     for data in all_charge
-                    if plot_label in all_charge[data]["plot_label"]
+                    if plot_label == all_charge[data]["plot_label"]
                 ]
                 x_values = [
                     x_tick_labels.index(all_charge[data]["x_label"])
                     for data in all_charge
-                    if plot_label in all_charge[data]["plot_label"]
+                    if plot_label == all_charge[data]["plot_label"]
                 ]
                 data_set = {
                     "label": plot_label,


### PR DESCRIPTION
If a plot label was part of a substring of another plot label, it was added to the plot data. For example, if the functional `PBE` and `PBE0` were plot labels, the data of `PBE0` was included to the `PBE` data. The change differentiates these two as separate plot labels and hence produces the desired plot data.