### PR TITLE
Parallelize comparison methods of `StructureOperations`

### DIFF
--- a/aim2dat/ml/cell_grid_search.py
+++ b/aim2dat/ml/cell_grid_search.py
@@ -309,18 +309,18 @@ class CellGridSearch:
 
     def _compare_with_target_structure_ffprint(self, labels):
         scores = []
+        comparisons = self._strct_ops.compare_structures_via_ffingerprint(
+            labels,
+            "target",
+            r_max=self.ffprint_r_max,
+            delta_bin=self.ffprint_delta_bin,
+            sigma=self.ffprint_sigma,
+            use_weights=self.ffprint_use_weights,
+            distinguish_kinds=self.ffprint_distinguish_kinds,
+        )
+
         for label in labels:
-            scores.append(
-                self._strct_ops.compare_structures_via_ffingerprint(
-                    label,
-                    "target",
-                    r_max=self.ffprint_r_max,
-                    delta_bin=self.ffprint_delta_bin,
-                    sigma=self.ffprint_sigma,
-                    use_weights=self.ffprint_use_weights,
-                    distinguish_kinds=self.ffprint_distinguish_kinds,
-                )
-            )
+            scores.append(comparisons[(label, "target")])
         return scores
 
     def _get_model_predictions(self, labels):

--- a/tests/ml/test_metrics.py
+++ b/tests/ml/test_metrics.py
@@ -28,17 +28,15 @@ def test_ffprint_cosine(create_structure_collection_object, structure1, structur
     )
 
     fingerprints = transf.fit_transform(strct_c)
+    comp = StructureOperations(structures=strct_c).compare_structures_via_ffingerprint(
+        structure1,
+        structure2,
+        r_max=r_max,
+        delta_bin=delta_bin,
+        sigma=sigma,
+        use_weights=use_weights,
+    )
     assert (
-        abs(
-            ffprint_cosine(fingerprints[0], fingerprints[1])
-            - StructureOperations(structures=strct_c).compare_structures_via_ffingerprint(
-                structure1,
-                structure2,
-                r_max=r_max,
-                delta_bin=delta_bin,
-                sigma=sigma,
-                use_weights=use_weights,
-            )
-        )
+        abs(ffprint_cosine(fingerprints[0], fingerprints[1]) - comp[(structure1, structure2)])
         < 1.0e-5
     )

--- a/tests/strct/test_structure_op_compare_functions.py
+++ b/tests/strct/test_structure_op_compare_functions.py
@@ -47,7 +47,9 @@ def test_compare_structures_via_ffingerprint(
     strct_ops = StructureOperations(strct_collect)
     assert (
         abs(
-            strct_ops.compare_structures_via_ffingerprint(structure1, structure2, **ffprint_args)
+            strct_ops.compare_structures_via_ffingerprint(structure1, structure2, **ffprint_args)[
+                (structure1, structure2)
+            ]
             - ref_value
         )
         < 1.0e-4


### PR DESCRIPTION
This PR enables the comparison of multiple structures at the same time. Moreover, the `compare_structures_via<method>` methods do also support parallelization now. 

Regarding the comparison of multiple structures:

- If two lists of keys with the same lengths are provided, a pairwise comparison is performed
- If the lengths differ, `itertools.product` is used to perform all possible pairwise comparisons

@hdsassnick I also adjusted the methods in the `ml` module, to take advantage of the new changes. Please let me know if you want to change something.