### PR TITLE
Add hatch to bar plot

### DIFF
--- a/aim2dat/plots/base_plot.py
+++ b/aim2dat/plots/base_plot.py
@@ -112,12 +112,12 @@ class _BasePlot(abc.ABC):
         "_add_hline",
         "_add_text",
     ]
-    _default_colors = [f"C{idx}" for idx in range(10)]
+    _legendolors = [f"C{idx}" for idx in range(10)]
     _default_linestyles = ["solid", "dashed", "dotted", "dashdot", "solid", "solid"]
     _default_linewidths = [None]
     _default_markers = ["*", "o", ">", "s", "v", "h", "D"]
-    _default_hatch = [0.5]
-    _default_alpha = []
+    _default_hatch = []
+    _default_alpha = [0.5]
 
     def __init__(self, **kwargs):
         """Initialize class."""

--- a/aim2dat/plots/base_plot.py
+++ b/aim2dat/plots/base_plot.py
@@ -112,7 +112,7 @@ class _BasePlot(abc.ABC):
         "_add_hline",
         "_add_text",
     ]
-    _legendolors = [f"C{idx}" for idx in range(10)]
+    _default_colors = [f"C{idx}" for idx in range(10)]
     _default_linestyles = ["solid", "dashed", "dotted", "dashdot", "solid", "solid"]
     _default_linewidths = [None]
     _default_markers = ["*", "o", ">", "s", "v", "h", "D"]

--- a/aim2dat/plots/base_plot.py
+++ b/aim2dat/plots/base_plot.py
@@ -116,7 +116,8 @@ class _BasePlot(abc.ABC):
     _default_linestyles = ["solid", "dashed", "dotted", "dashdot", "solid", "solid"]
     _default_linewidths = [None]
     _default_markers = ["*", "o", ">", "s", "v", "h", "D"]
-    _default_alpha = [0.5]
+    _default_hatch = [0.5]
+    _default_alpha = []
 
     def __init__(self, **kwargs):
         """Initialize class."""
@@ -155,6 +156,7 @@ class _BasePlot(abc.ABC):
         self._custom_linestyles = None
         self._custom_linewidths = None
         self._custom_markers = None
+        self._custom_hatch = None
         self._custom_alpha = None
         self._custom_xticks = None
         self._custom_xticklabels = None
@@ -485,6 +487,17 @@ class _BasePlot(abc.ABC):
     @custom_markers.setter
     def custom_markers(self, value):
         self._custom_markers = value
+
+    @property
+    def custom_hatch(self):
+        """float, list or tuple: Hatch value(s) controlling the hatch of plot elements."""
+        return self._custom_hatch
+
+    @custom_hatch.setter
+    def custom_hatch(self, value):
+        if not isinstance(value, (list, tuple)):
+            value = (value,)
+        self._custom_hatch = value
 
     @property
     def custom_alpha(self):
@@ -981,6 +994,8 @@ class _BasePlot(abc.ABC):
             data_set["linewidth"] = swap_attr(data_set["linewidth"], "linewidths")
         if "marker" in data_set:
             data_set["marker"] = swap_attr(data_set["marker"], "markers")
+        if "hatch" in data_set:
+            data_set["hatch"] = swap_attr(data_set["hatch"], "hatch")
         if "alpha" in data_set:
             data_set["alpha"] = swap_attr(data_set["alpha"], "alpha")
 

--- a/aim2dat/plots/matplotlib_backend.py
+++ b/aim2dat/plots/matplotlib_backend.py
@@ -16,6 +16,7 @@ MATPLOTLIB_ARGS = [
     "linewidth",
     "color",
     "facecolor",
+    "hatch",
     "alpha",
 ]
 
@@ -343,6 +344,7 @@ def _add_bar(obj, axes, bar):
         bottom=bar.get("bottom", 0),
         align=bar.get("align", "center"),
         color=bar.get("color", None),
+        hatch=bar.get("hatch", None),
         alpha=bar.get("alpha", None),
         label=bar.get("label", None),
     )

--- a/aim2dat/plots/simple_plot.py
+++ b/aim2dat/plots/simple_plot.py
@@ -104,6 +104,7 @@ class SimplePlot(_BasePlot, _HLineMixin, _VLineMixin):
         heights,
         plot_label=None,
         color=None,
+        hatch=None,
         alpha=None,
         bottom=0.0,
         width=0.8,
@@ -126,6 +127,8 @@ class SimplePlot(_BasePlot, _HLineMixin, _VLineMixin):
             Label of the data set shown in the legend.
         color : str (optional)
             Color of the data set.
+        hatch : str (optional)
+            Hatch of the data set.
         alpha : float (optional)
             Transparency of the data set.
         bottom : float
@@ -151,6 +154,8 @@ class SimplePlot(_BasePlot, _HLineMixin, _VLineMixin):
             data_set["label"] = plot_label
         if color is not None:
             data_set["color"] = color
+        if hatch is not None:
+            data_set["hatch"] = hatch
         if alpha is not None:
             data_set["alpha"] = alpha
         self._data[data_label] = data_set

--- a/example_notebooks/plots-simple_plot.ipynb
+++ b/example_notebooks/plots-simple_plot.ipynb
@@ -62,6 +62,7 @@
     "    width=0.15,\n",
     "    bottom=1.5,\n",
     "    color=\"C4\",\n",
+    "    hatch=[\"\",\"///\"],\n",
     ")"
    ]
   },
@@ -242,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds the option ```hatch``` to  ```import_bar_data_set``` in the ```SimploPlot``` class to differentiate bar plots if they share key properties but need to be differentiated somehow. 