### PR TITLE
Speed-up n-nearest-neighbours method to calculate coordination and user interface updates.

### DIFF
--- a/aim2dat/ml/transformers.py
+++ b/aim2dat/ml/transformers.py
@@ -327,6 +327,13 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
     n_nearest_neighbours : int (optional)
         Number of neighbours that are considered coordinated for the ``'n_neighbours'``
         method.
+    radius_type : str (optional)
+        Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
+        used as fallback in the radius for an element is not defined).
+    atomic_radius_delta : float (optional)
+        Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
+        If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
+        positive (negative) values increase (decrease) the threshold.
     econ_tolerance : float (optional)
         Tolerance parameter for the econ method.
     econ_conv_threshold : float (optional)
@@ -366,6 +373,8 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
         "method",
         "min_dist_delta",
         "n_nearest_neighbours",
+        "radius_type",
+        "atomic_radius_delta",
         "econ_tolerance",
         "econ_conv_threshold",
         "voronoi_weight_type",
@@ -378,6 +387,8 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
         method="minimum_distance",
         min_dist_delta=0.1,
         n_nearest_neighbours=5,
+        radius_type="chen_manz",
+        atomic_radius_delta=0.0,
         econ_tolerance=0.5,
         econ_conv_threshold=0.001,
         voronoi_weight_type="rel_solid_angle",

--- a/aim2dat/ml/transformers.py
+++ b/aim2dat/ml/transformers.py
@@ -414,6 +414,8 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
         self.method = method
         self.min_dist_delta = min_dist_delta
         self.n_nearest_neighbours = n_nearest_neighbours
+        self.radius_type = radius_type
+        self.atomic_radius_delta = atomic_radius_delta
         self.econ_tolerance = econ_tolerance
         self.econ_conv_threshold = econ_conv_threshold
         self.voronoi_weight_type = voronoi_weight_type

--- a/aim2dat/strct/strct_coordination.py
+++ b/aim2dat/strct/strct_coordination.py
@@ -257,10 +257,7 @@ def _coord_calculate_n_nearest_neighbours(
     el_idx_sc = indices_sc.index(site_idx)
     position = np.array(structure.positions[site_idx])
     neighbours = []
-    zipped = list(zip(dist_matrix[site_idx].tolist(), range(len(elements_sc))))
-    zipped.sort(key=lambda point: point[0])
-    _, sc_indices = zip(*zipped)
-
+    sc_indices = np.argsort(dist_matrix[site_idx])
     for idx in sc_indices[1 : n_neighbours + 1]:
         neigh_pos = position + (np.array(positions_sc[idx]) - np.array(positions_sc[el_idx_sc]))
         neighbours.append((mapping[idx], neigh_pos, dist_matrix[site_idx][idx]))

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -727,6 +727,8 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         cn_method: str = "minimum_distance",
         min_dist_delta: float = 0.1,
         n_nearest_neighbours: int = 5,
+        radius_type: str = "chen_manz",
+        atomic_radius_delta: float = 0.0,
         econ_tolerance: float = 0.5,
         econ_conv_threshold: float = 0.001,
         voronoi_weight_type: float = "rel_solid_angle",
@@ -759,6 +761,13 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         n_nearest_neighbours : int (optional)
             Number of neighbours that are considered coordinated for the ``'n_neighbours'``
             method.
+        radius_type : str (optional)
+            Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
+            used as fallback in the radius for an element is not defined).
+        atomic_radius_delta : float (optional)
+            Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
+            If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
+            positive (negative) values increase (decrease) the threshold.
         econ_tolerance : float (optional)
             Tolerance parameter for the econ method.
         econ_conv_threshold : float (optional)
@@ -884,6 +893,8 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         cn_method: str = "minimum_distance",
         min_dist_delta: float = 0.1,
         n_nearest_neighbours: int = 5,
+        radius_type: str = "chen_manz",
+        atomic_radius_delta: float = 0.0,
         econ_tolerance: float = 0.5,
         econ_conv_threshold: float = 0.001,
         voronoi_weight_type: float = "rel_solid_angle",
@@ -910,6 +921,13 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         n_nearest_neighbours : int (optional)
             Number of neighbours that are considered coordinated for the ``'n_neighbours'``
             method.
+        radius_type : str (optional)
+            Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
+            used as fallback in the radius for an element is not defined).
+        atomic_radius_delta : float (optional)
+            Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
+            If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
+            positive (negative) values increase (decrease) the threshold.
         econ_tolerance : float (optional)
             Tolerance parameter for the econ method.
         econ_conv_threshold : float (optional)

--- a/tests/strct/coordination/Cs2Te_62_prim_n_nearest_neighbours.yaml
+++ b/tests/strct/coordination/Cs2Te_62_prim_n_nearest_neighbours.yaml
@@ -36,7 +36,7 @@ ref:
       kind:
       site_index: 7
       distance: 4.435553188187956
-      position: [6.197535938000001, 1.472817, -0.8484619909999982]
+      position: [6.197535938000001, 7.364085, -0.8484619909999982]
   - Cs: 0
     Te: 5
     element: Cs
@@ -66,12 +66,12 @@ ref:
       kind:
       site_index: 9
       distance: 4.426669939794483
-      position: [2.415988586, -1.472817, 4.509633596]
+      position: [2.415988586, 4.418451, 4.509633596]
     - element: Te
       kind:
       site_index: 9
       distance: 4.426669939794483
-      position: [2.415988586, 4.418451, 4.509633596]
+      position: [2.415988586, -1.472817, 4.509633596]
   - Cs: 0
     Te: 5
     element: Cs
@@ -141,7 +141,7 @@ ref:
       kind:
       site_index: 4
       distance: 4.433325541961325
-      position: [10.972216938, 1.472817, 6.659845491]
+      position: [10.972216938, 7.364085, 6.659845491]
   - Cs: 1
     Te: 4
     element: Cs
@@ -161,12 +161,12 @@ ref:
       kind:
       site_index: 9
       distance: 3.779746724073622
-      position: [2.415988586, -1.472817, 4.509633596]
+      position: [2.415988586, 4.418451, 4.509633596]
     - element: Te
       kind:
       site_index: 9
       distance: 3.779746724073622
-      position: [2.415988586, 4.418451, 4.509633596]
+      position: [2.415988586, -1.472817, 4.509633596]
     - element: Te
       kind:
       site_index: 10
@@ -241,12 +241,12 @@ ref:
       kind:
       site_index: 10
       distance: 4.4276087976423195
-      position: [7.133373414, 1.472817, 7.113133404]
+      position: [7.133373414, 7.364085, 7.113133404]
     - element: Te
       kind:
       site_index: 10
       distance: 4.4276087976423195
-      position: [7.133373414, 7.364085, 7.113133404]
+      position: [7.133373414, 1.472817, 7.113133404]
   - Cs: 1
     Te: 4
     element: Cs
@@ -371,12 +371,12 @@ ref:
       kind:
       site_index: 3
       distance: 3.779746724073622
-      position: [8.126507062, -1.472817, 4.962921509]
+      position: [8.126507062, 4.418451, 4.962921509]
     - element: Cs
       kind:
       site_index: 3
       distance: 3.779746724073622
-      position: [8.126507062, 4.418451, 4.962921509]
+      position: [8.126507062, -1.472817, 4.962921509]
     - element: Cs
       kind:
       site_index: 4

--- a/tests/strct/coordination/GaAs_216_conv_n_nearest_neighbours.yaml
+++ b/tests/strct/coordination/GaAs_216_conv_n_nearest_neighbours.yaml
@@ -14,6 +14,11 @@ ref:
     neighbours:
     - element: As
       kind:
+      site_index: 6
+      distance: 3.521259291787527
+      position: [2.033, -2.032999999999999, 2.033]
+    - element: As
+      kind:
       site_index: 4
       distance: 3.521259291787526
       position: [-2.032999999999999, -2.032999999999999, -2.032999999999999]
@@ -22,11 +27,6 @@ ref:
       site_index: 5
       distance: 3.521259291787527
       position: [2.033, 2.033, -2.032999999999999]
-    - element: As
-      kind:
-      site_index: 6
-      distance: 3.521259291787527
-      position: [2.033, -2.032999999999999, 2.033]
     - element: As
       kind:
       site_index: 7
@@ -44,11 +44,6 @@ ref:
     neighbours:
     - element: As
       kind:
-      site_index: 5
-      distance: 3.5212592917875285
-      position: [2.033, 10.165, 6.099]
-    - element: As
-      kind:
       site_index: 6
       distance: 3.5212592917875285
       position: [2.033, 14.231, 2.033]
@@ -57,6 +52,11 @@ ref:
       site_index: 7
       distance: 3.521259291787527
       position: [-2.032999999999999, 10.165, 2.033]
+    - element: As
+      kind:
+      site_index: 5
+      distance: 3.5212592917875285
+      position: [2.033, 10.165, 6.099]
     - element: As
       kind:
       site_index: 4
@@ -79,14 +79,14 @@ ref:
       position: [2.033, 2.033, 6.099000000000001]
     - element: As
       kind:
-      site_index: 6
-      distance: 3.521259291787527
-      position: [2.033, -2.032999999999999, 2.033]
-    - element: As
-      kind:
       site_index: 7
       distance: 3.5212592917875285
       position: [6.099000000000001, 2.033, 2.033]
+    - element: As
+      kind:
+      site_index: 6
+      distance: 3.521259291787527
+      position: [2.033, -2.032999999999999, 2.033]
     - element: As
       kind:
       site_index: 4
@@ -139,11 +139,6 @@ ref:
       position: [8.132, 8.132, 8.132]
     - element: Ga
       kind:
-      site_index: 1
-      distance: 3.5212592917875285
-      position: [8.132, 4.066, 4.066]
-    - element: Ga
-      kind:
       site_index: 2
       distance: 3.5212592917875285
       position: [4.066, 8.132, 4.066]
@@ -152,6 +147,11 @@ ref:
       site_index: 3
       distance: 3.5212592917875285
       position: [4.066, 4.066, 8.132]
+    - element: Ga
+      kind:
+      site_index: 1
+      distance: 3.5212592917875285
+      position: [8.132, 4.066, 4.066]
   - Ga: 4
     As: 0
     element: As
@@ -164,14 +164,14 @@ ref:
     neighbours:
     - element: Ga
       kind:
-      site_index: 0
-      distance: 3.5212592917875267
-      position: [0.0, 0.0, 8.132]
-    - element: Ga
-      kind:
       site_index: 3
       distance: 3.5212592917875267
       position: [4.066, 4.066, 8.132]
+    - element: Ga
+      kind:
+      site_index: 0
+      distance: 3.5212592917875267
+      position: [0.0, 0.0, 8.132]
     - element: Ga
       kind:
       site_index: 1
@@ -194,14 +194,14 @@ ref:
     neighbours:
     - element: Ga
       kind:
-      site_index: 0
-      distance: 3.5212592917875267
-      position: [0.0, 8.132, 0.0]
-    - element: Ga
-      kind:
       site_index: 2
       distance: 3.5212592917875267
       position: [4.066, 8.132, 4.066]
+    - element: Ga
+      kind:
+      site_index: 0
+      distance: 3.5212592917875267
+      position: [0.0, 8.132, 0.0]
     - element: Ga
       kind:
       site_index: 1
@@ -234,14 +234,14 @@ ref:
       position: [8.132, 4.066, 4.066]
     - element: Ga
       kind:
-      site_index: 2
-      distance: 3.5212592917875285
-      position: [4.066, 0.0, 4.066]
-    - element: Ga
-      kind:
       site_index: 3
       distance: 3.5212592917875285
       position: [4.066, 4.066, 0.0]
+    - element: Ga
+      kind:
+      site_index: 2
+      distance: 3.5212592917875285
+      position: [4.066, 0.0, 4.066]
   nrs_avg:
     &id001 [Ga, Ga]: 0
     &id002 [Ga, As]: 4


### PR DESCRIPTION
Using ``np.argsort`` is a lot quicker than zipping and sorting for large structures. In addition the user interface of the functions/classes relying on ``calculate_coordination`` are updated.