### PR TITLE
Bugfix for ``io.cif.read_file`` function.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Version 0.3.0
 * Expose ``strct.Structure.attributes``, ``strct.Structure.site_attributes`` and ``strct.Structure.extras`` to ``strct.StructureCollection.append``, ``strct.Structure.from_ase_atoms`` and ``strct.Structure.from_pymatgen_structure`` functions (`PR #103 <https://github.com/aim2dat/aim2dat/pull/103>`_).
 * Some str values were sometimes wrongly transformed into float numbers in the output parsers and cif parser checks more rigorously whether two atoms are occupying the same site (`PR #104 <https://github.com/aim2dat/aim2dat/pull/104>`_).
 * Fix positions returned from ``strct.Structure.calculate_distance`` function (`PR #106 <https://github.com/aim2dat/aim2dat/pull/106>`_).
+* ``io.cif.read_file`` was not properly parsing string values in loops with delimiters ("" or '') and without spaces (`PR #118 <https://github.com/aim2dat/aim2dat/pull/118>`_).
 
 **Breaking Changes:**
 

--- a/aim2dat/io/cif.py
+++ b/aim2dat/io/cif.py
@@ -335,20 +335,18 @@ class _CIFDataBlock:
         line_split = line.split()
         loop_values = []
         str_val_limiter = None
-        string_val = None
         for val in line_split:
-            if val[0] in self._string_limiters and string_val is None:
+            if val[0] in self._string_limiters and str_val_limiter is None:
                 str_val_limiter = val[0]
-                string_val = val[1:] if len(val) > 1 else ""
-            elif string_val is not None:
-                string_val += " " + val
+                val = val[1:] if len(val) > 1 else ""
+                loop_values.append("")
+            if str_val_limiter is not None:
                 if val.endswith(str_val_limiter):
-                    string_val = string_val[:-1]
-                    loop_values.append(string_val)
-                    string_val = None
+                    val = val[:-1]
+                    str_val_limiter = None
+                loop_values[-1] += " " + val
             else:
                 loop_values.append(val)
-
         return [transform_str_value(val) for val in loop_values]
 
     def _finalize_current_loop(self, line_idx, line):
@@ -360,6 +358,7 @@ class _CIFDataBlock:
             len(self.current_loop["values"][0]) != len(self.current_loop["values"][idx])
             for idx in range(len(self.current_loop["values"]))
         ):
+            print(self.current_loop)
             raise ValueError(f"Number of values differ for loop finishing on line {line_idx}.")
         self.loops.append(
             {

--- a/tests/io/cif/loop_test.cif
+++ b/tests/io/cif/loop_test.cif
@@ -28,7 +28,7 @@ loop_
   _platon_squeeze_void_count_electrons
   _platon_squeeze_void_content
    1 -0.01 -0.025
-   -0.5     10     20 ' '
+   -0.5     '10'     20 ' '
 
 loop_
   _symmetry_equiv_pos_site_id


### PR DESCRIPTION
The ``io.cif.read_file`` function wasn't considering single string values with string delimiters in loops.