### PR TITLE
Add distance check to ``strct.ext_manipulation.add_structure_position`` function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ Version 0.3.0
 
 * A parser for xml output files of Quantum ESPRESSO is added (`PR #102 <https://github.com/aim2dat/aim2dat/pull/102>`_).
 * Added interface to MOFXDB (https://mof.tech.northwestern.edu/) to the ``strct.StructureImporter`` class (`PR #94 <https://github.com/aim2dat/aim2dat/pull/94>`_).
-* The newly implemented ``strct.ext_manipulation.add_structure_position`` function adds a guest structure at a given position (`PR #105 <https://github.com/aim2dat/aim2dat/pull/105>`_).
+* The newly implemented ``strct.ext_manipulation.add_structure_position`` function adds a guest structure at a given position (`PR #105 <https://github.com/aim2dat/aim2dat/pull/105>`_ and `PR #123 <https://github.com/aim2dat/aim2dat/pull/123>`_).
 * The newly implemented ``strct.ext_manipulation.rotate_structure`` function rotates a sub structure around a certain point or vector (`PR #105 <https://github.com/aim2dat/aim2dat/pull/105>`_).
 * The ``strct.Structure`` class checks now for duplicate positions upon initialization (`PR #107 <https://github.com/aim2dat/aim2dat/pull/107>`_).
 * ``strct.ext_analysis.determine_molecular_fragments`` offers additional parameters, allowing to exclude sites and restricting the size of the fragments (`PR #111 <https://github.com/aim2dat/aim2dat/pull/111>`_).

--- a/aim2dat/strct/ext_manipulation/add_structure.py
+++ b/aim2dat/strct/ext_manipulation/add_structure.py
@@ -309,6 +309,7 @@ def add_structure_position(
     position: List[float],
     guest_structure: Union[Structure, str] = "CH3",
     wrap: bool = False,
+    dist_threshold: float = None,
     change_label: bool = False,
 ) -> Structure:
     """
@@ -327,6 +328,9 @@ def add_structure_position(
         or the element symbol to add one single atom.
     wrap : bool (optional)
         Wrap atomic positions back into the unit cell.
+    dist_threshold : float or None (optional)
+        Check the distances between all site pairs of the host and guest structure to ensure that
+        none of the added atoms collide.
     change_label : bool (optional)
         Add suffix to the label of the new structure highlighting the performed manipulation.
 
@@ -345,6 +349,7 @@ def add_structure_position(
     guest_strct0.set_positions(guest_positions)
 
     new_structure = _merge_structures(structure, guest_strct0, wrap)
+    _check_distances(new_structure, len(guest_strct["elements"]), dist_threshold, False)
 
     return new_structure, "_added-" + guest_strct_label
 

--- a/tests/strct/test_structure_manipulation_functions.py
+++ b/tests/strct/test_structure_manipulation_functions.py
@@ -178,6 +178,15 @@ def test_add_structure_position(structure_comparison):
     ref_p = load_yaml_file(STRUCTURE_MANIPULATION_PATH + "PBI3+CN2H5_ref.yaml")
     structure_comparison(new_strct, ref_p)
 
+    with pytest.raises(ValueError) as error:
+        new_strct = add_structure_position(
+            Structure(**inputs[0]),
+            position=[2.88759377, 3.244215, 3.25149],
+            guest_structure=Structure(**inputs[1]),
+            dist_threshold=10.0,
+        )
+    assert str(error.value) == "Atoms are too close to each other."
+
 
 def test_scale_unit_cell_errors():
     """Test appropriate error rasing of scale_unit_cell function."""


### PR DESCRIPTION
Adds ``dist_threshold`` kwarg to ``strct.ext_manipulation.add_structure_position`` to make it consistent to the other functions and adjusts the test.