### PR TITLE
added cn_kwarks parameters to calculate_coordination function

### DIFF
--- a/aim2dat/ml/transformers.py
+++ b/aim2dat/ml/transformers.py
@@ -455,8 +455,8 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
             f_labels += [feature + "_" + "-".join(el_pair) for el_pair in self.el_pairs_]
         self._features_out = np.asarray(f_labels, dtype=object)
 
-    def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].calculate_coordination(**input_p)
+    def _get_strct_op_properties(self, label_list, strct_op, cn_kwarks):
+        return strct_op[label_list].calculate_coordination(**cn_kwarks)
 
     def _get_features(self, label_list, strct_op, input_p):
         check_is_fitted(self, attributes="el_pairs_")

--- a/aim2dat/strct/ext_analysis/fragmentation.py
+++ b/aim2dat/strct/ext_analysis/fragmentation.py
@@ -18,17 +18,7 @@ def determine_molecular_fragments(
     exclude_elements: List[str] = None,
     exclude_sites: List[int] = None,
     end_point_elements: List[str] = None,
-    r_max: float = 10.0,
-    cn_method: str = "minimum_distance",
-    min_dist_delta: float = 0.1,
-    n_nearest_neighbours: int = 5,
-    radius_type: str = "chen_manz",
-    atomic_radius_delta: float = 0.0,
-    econ_tolerance: float = 0.5,
-    econ_conv_threshold: float = 0.001,
-    voronoi_weight_type: float = "rel_solid_angle",
-    voronoi_weight_threshold: float = 0.5,
-    okeeffe_weight_threshold: float = 0.5,
+    **cn_kwarks
 ) -> List[Structure]:
     """
     Find molecular fragments in a larger molecule/cluster of periodic crystal.
@@ -45,33 +35,14 @@ def determine_molecular_fragments(
         List of site indices that are excluded from the search.
     end_point_elements : list
         List of elements that serve as an end point for a fragment.
-    r_max : float (optional)
-        Cut-off value for the maximum distance between two atoms in angstrom.
-    cn_method : str (optional)
-        Method used to calculate the coordination environment.
-    min_dist_delta : float (optional)
-        Tolerance parameter that defines the relative distance from the nearest neighbour atom
-        for the ``'minimum_distance'`` method.
-    n_nearest_neighbours : int (optional)
-        Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-        method.
-    radius_type : str (optional)
-        Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-        used as fallback in the radius for an element is not defined).
-    atomic_radius_delta : float (optional)
-        Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-        If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-        positive (negative) values increase (decrease) the threshold.
-    econ_tolerance : float (optional)
-        Tolerance parameter for the econ method.
-    econ_conv_threshold : float (optional)
-        Convergence threshold for the econ method.
-    voronoi_weight_type : str (optional)
-        Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-        ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-        weights with respect to the maximum value of the polyhedron are calculated.
-    voronoi_weight_threshold : float (optional)
-        Weight threshold to consider a neighbouring atom coordinated.
+    cn_kwarks : keyword argument pair (optional)
+        Keys and arguments used for the coordination method implemented in 
+        `aim2dat.strct.strct_coordination.calculate_coordination`. 
+        Supported arguments are:
+        ``'r_max'``, ``'method'``, ``'min_dist_delta'``, ``'n_nearest_neighbours'``,
+        ``'radius_type'``, ``'atomic_radius_delta'``, ``'econ_tolerance'``,
+        ``'econ_conv_threshold'``, ``'voronoi_weight_type'``, ``'voronoi_weight_threshold'``,
+        ``'okeeffe_weight_threshold'``
 
     Returns
     -------
@@ -86,19 +57,7 @@ def determine_molecular_fragments(
         end_point_elements = []
     used_site_indices = []
     molecular_fragments = []
-    coord = structure.calculate_coordination(
-        r_max=r_max,
-        method=cn_method,
-        min_dist_delta=min_dist_delta,
-        n_nearest_neighbours=n_nearest_neighbours,
-        radius_type=radius_type,
-        atomic_radius_delta=atomic_radius_delta,
-        econ_tolerance=econ_tolerance,
-        econ_conv_threshold=econ_conv_threshold,
-        voronoi_weight_type=voronoi_weight_type,
-        voronoi_weight_threshold=voronoi_weight_threshold,
-        okeeffe_weight_threshold=okeeffe_weight_threshold,
-    )
+    coord = structure.calculate_coordination(**cn_kwarks)
 
     allowed_sites = []
     for site_idx, el in enumerate(structure.elements):

--- a/aim2dat/strct/ext_analysis/graphs.py
+++ b/aim2dat/strct/ext_analysis/graphs.py
@@ -18,16 +18,7 @@ def create_graph(
     get_graphviz_graph: bool = False,
     graphviz_engine: str = "circo",
     graphviz_edge_rank_colors: List[str] = ["blue", "red", "green", "orange", "darkblue"],
-    r_max: float = 10.0,
-    cn_method: str = "minimum_distance",
-    min_dist_delta: float = 0.1,
-    n_nearest_neighbours: int = 5,
-    radius_type: str = "chen_manz",
-    atomic_radius_delta: float = 0.0,
-    econ_tolerance: float = 0.5,
-    econ_conv_threshold: float = 0.001,
-    voronoi_weight_type: float = "rel_solid_angle",
-    voronoi_weight_threshold: float = 0.5,
+    **cn_kwarks
 ):
     """
     Create graph based on the coordination.
@@ -42,35 +33,14 @@ def create_graph(
         Graphviz engine used to create the graph. The default value is ``'circo'``.
     graphviz_edge_rank_colors : list
         List of colors of the different edge ranks.
-    r_max : float
-        Cut-off value for the maximum distance between two atoms in angstrom. The default
-        value is set to ``20.0``.
-    cn_method : str
-        Method used to calculate the coordination environment. The default value is
-        ``'minimum_distance'``.
-    min_dist_delta : float
-        Tolerance parameter that defines the relative distance from the nearest neighbour atom
-        for the ``'minimum_distance'`` method. The default value is ``0.1``.
-    n_nearest_neighbours : int
-        Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-        method. The default value is ``5``.
-    radius_type : str (optional)
-        Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-        used as fallback in the radius for an element is not defined).
-    atomic_radius_delta : float (optional)
-        Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-        If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-        positive (negative) values increase (decrease) the threshold.
-    econ_tolerance : float
-        Tolerance parameter for the econ method. The default value is ``0.5``.
-    econ_conv_threshold : float
-        Convergence threshold for the econ method. The default value is ``0.001``.
-    voronoi_weight_type : str (optional)
-        Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-        ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-        weights with respect to the maximum value of the polyhedron are calculated.
-    voronoi_weight_threshold : float (optional)
-        Weight threshold to consider a neighbouring atom coordinated.
+    cn_kwarks : keyword argument pair (optional)
+        Keys and arguments used for the coordination method implemented in 
+        `aim2dat.strct.strct_coordination.calculate_coordination`. 
+        Supported arguments are:
+        ``'r_max'``, ``'method'``, ``'min_dist_delta'``, ``'n_nearest_neighbours'``,
+        ``'radius_type'``, ``'atomic_radius_delta'``, ``'econ_tolerance'``,
+        ``'econ_conv_threshold'``, ``'voronoi_weight_type'``, ``'voronoi_weight_threshold'``,
+        ``'okeeffe_weight_threshold'``
 
     Returns
     -------
@@ -79,18 +49,7 @@ def create_graph(
     graphviz_graph : graphviz.Digraph
         graphviz graph of the structure (if ``get_graphviz_graph`` is set to ``True``).
     """
-    coord = structure.calculate_coordination(
-        r_max=r_max,
-        method=cn_method,
-        min_dist_delta=min_dist_delta,
-        n_nearest_neighbours=n_nearest_neighbours,
-        radius_type=radius_type,
-        atomic_radius_delta=atomic_radius_delta,
-        econ_tolerance=econ_tolerance,
-        econ_conv_threshold=econ_conv_threshold,
-        voronoi_weight_type=voronoi_weight_type,
-        voronoi_weight_threshold=voronoi_weight_threshold,
-    )
+    coord = structure.calculate_coordination(**cn_kwarks)
     nx_graph = nx.MultiDiGraph()
     for site_idx, site in enumerate(coord["sites"]):
         nx_graph.add_node(site_idx, element=site["element"])

--- a/aim2dat/strct/ext_manipulation/add_structure.py
+++ b/aim2dat/strct/ext_manipulation/add_structure.py
@@ -117,7 +117,7 @@ def add_structure_coord(
     **cn_kwarks,
 ) -> Structure:
     """
-    Add a functional group or an atom to a host site.
+    Add a guest structure to a host structure at defined sites.
 
     Parameters
     ----------
@@ -161,7 +161,7 @@ def add_structure_coord(
     Returns
     -------
     aim2dat.strct.Structure
-        Structure with attached functional group.
+        Structure with attached guest structure.
     """
     guest_strct, guest_strct_label = _check_guest_structure(guest_structure)
     if isinstance(host_indices, int):

--- a/aim2dat/strct/ext_manipulation/add_structure.py
+++ b/aim2dat/strct/ext_manipulation/add_structure.py
@@ -111,20 +111,10 @@ def add_structure_coord(
     guest_structure: Union[Structure, str] = "CH3",
     guest_dir: Union[None, List[float]] = None,
     bond_length: float = 1.25,
-    r_max: float = 15.0,
-    cn_method: str = "minimum_distance",
-    min_dist_delta: float = 0.1,
-    n_nearest_neighbours: int = 5,
-    radius_type: str = "chen_manz",
-    atomic_radius_delta: float = 0.0,
-    econ_tolerance: float = 0.5,
-    econ_conv_threshold: float = 0.001,
-    voronoi_weight_type: float = "rel_solid_angle",
-    voronoi_weight_threshold: float = 0.5,
-    okeeffe_weight_threshold: float = 0.5,
     dist_constraints=[],
     dist_threshold: Union[float, None] = 0.8,
     change_label: bool = False,
+    **cn_kwarks,
 ) -> Structure:
     """
     Add a functional group or an atom to a host site.
@@ -149,26 +139,6 @@ def add_structure_coord(
         neighbors is constructed based on the guest index.
     bond_length : float
         Bond length between the host atom and the base atom of the functional group.
-    r_max : float (optional)
-        Cut-off value for the maximum distance between two atoms in angstrom.
-    cn_method : str (optional)
-        Method used to calculate the coordination environment.
-    min_dist_delta : float (optional)
-        Tolerance parameter that defines the relative distance from the nearest neighbour atom
-        for the ``'minimum_distance'`` method.
-    n_nearest_neighbours : int (optional)
-        Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-        method.
-    econ_tolerance : float (optional)
-        Tolerance parameter for the econ method.
-    econ_conv_threshold : float (optional)
-        Convergence threshold for the econ method.
-    voronoi_weight_type : str (optional)
-        Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-        ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-        weights with respect to the maximum value of the polyhedron are calculated.
-    voronoi_weight_threshold : float (optional)
-        Weight threshold to consider a neighbouring atom coordinated.
     dist_constraints : list (optional)
         List of three-fold tuples containing the index of the site of the host structure, the index
         of the site of the guest structure and the target distance. The position of the guest
@@ -179,7 +149,15 @@ def add_structure_coord(
         none of the added atoms collide.
     change_label : bool (optional)
         Add suffix to the label of the new structure highlighting the performed manipulation.
-
+    cn_kwarks : keyword argument pair (optional)
+        Keys and arguments used for the coordination method implemented in 
+        `aim2dat.strct.strct_coordination.calculate_coordination`. 
+        Supported arguments are:
+        ``'r_max'``, ``'method'``, ``'min_dist_delta'``, ``'n_nearest_neighbours'``,
+        ``'radius_type'``, ``'atomic_radius_delta'``, ``'econ_tolerance'``,
+        ``'econ_conv_threshold'``, ``'voronoi_weight_type'``, ``'voronoi_weight_threshold'``,
+        ``'okeeffe_weight_threshold'``
+        
     Returns
     -------
     aim2dat.strct.Structure
@@ -197,36 +175,12 @@ def add_structure_coord(
         guest_dir = [1.0, 0.0, 0.0]
         if len(guest_strct) > 1:
             # Get vector of guest atoms for rotation
-            guest_strct_coord = guest_strct.calculate_coordination(
-                r_max=r_max,
-                method=cn_method,
-                min_dist_delta=min_dist_delta,
-                n_nearest_neighbours=n_nearest_neighbours,
-                radius_type=radius_type,
-                atomic_radius_delta=atomic_radius_delta,
-                econ_tolerance=econ_tolerance,
-                econ_conv_threshold=econ_conv_threshold,
-                voronoi_weight_type=voronoi_weight_type,
-                voronoi_weight_threshold=voronoi_weight_threshold,
-                okeeffe_weight_threshold=okeeffe_weight_threshold,
-            )
+            guest_strct_coord = guest_strct.calculate_coordination(**cn_kwarks)
             guest_dir = -1.0 * _derive_bond_dir(guest_index, guest_strct_coord)
     guest_dir /= np.linalg.norm(np.array(guest_dir))
 
     # Calculate coordination:
-    coord = structure.calculate_coordination(
-        r_max=r_max,
-        method=cn_method,
-        min_dist_delta=min_dist_delta,
-        n_nearest_neighbours=n_nearest_neighbours,
-        radius_type=radius_type,
-        atomic_radius_delta=atomic_radius_delta,
-        econ_tolerance=econ_tolerance,
-        econ_conv_threshold=econ_conv_threshold,
-        voronoi_weight_type=voronoi_weight_type,
-        voronoi_weight_threshold=voronoi_weight_threshold,
-        okeeffe_weight_threshold=okeeffe_weight_threshold,
-    )
+    coord = structure.calculate_coordination(**cn_kwarks)
 
     # Derive bond directions and rotation to align guest towards bond direction:
     bond_dir = _derive_bond_dir(host_indices[0], coord)

--- a/aim2dat/strct/mixin.py
+++ b/aim2dat/strct/mixin.py
@@ -290,7 +290,7 @@ class AnalysisMixin:
     def calculate_coordination(
         self,
         r_max: float = 10.0,
-        method: str = "minimum_distance",
+        method: str = "atomic_radius",
         min_dist_delta: float = 0.1,
         n_nearest_neighbours: int = 5,
         radius_type: str = "chen_manz",
@@ -310,7 +310,7 @@ class AnalysisMixin:
             Cut-off value for the maximum distance between two atoms in angstrom.
         method : str (optional)
             Method used to calculate the coordination environment. The default value is
-            ``'minimum_distance'``.
+            ``'atomic_radius'``.
         min_dist_delta : float (optional)
             Tolerance parameter that defines the relative distance from the nearest neighbour atom
             for the ``'minimum_distance'`` method.

--- a/tests/strct/test_structure_c.py
+++ b/tests/strct/test_structure_c.py
@@ -137,7 +137,7 @@ def test_aiida_interface(create_structure_collection_object, structure_compariso
 
 def test_create_pandas_df(nested_dict_comparison):
     """Test pandas data frame creation."""
-    coord_kwargs = {
+    cn_kwargs = {
         "r_max": 5.0,
         "method": "minimum_distance",
         "min_dist_delta": 0.1,
@@ -149,7 +149,7 @@ def test_create_pandas_df(nested_dict_comparison):
     for strct in structures:
         strct_collect.append(strct, **dict(load_yaml_file(STRUCTURES_PATH + strct + ".yaml")))
     strct_ops = StructureOperations(strct_collect)
-    strct_ops[strct_collect.labels].calculate_coordination(**coord_kwargs)
+    strct_ops[strct_collect.labels].calculate_coordination(**cn_kwargs)
     df = strct_collect.create_pandas_df()
     df_dict = {}
     for column in df.columns:
@@ -355,7 +355,7 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
     """Test storage of calculated data."""
     strct_list = ["GaAs_216_prim", "Cs2Te_19_prim"]
     strct_c, structures = create_structure_collection_object(strct_list, "")
-    function_args = {
+    cn_kwarks = {
         "r_max": 10.0,
         "method": "minimum_distance",
         "min_dist_delta": 0.1,
@@ -369,16 +369,16 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
         "okeeffe_weight_threshold": 0.5,
     }
     strct_ops = StructureOperations(strct_c)
-    coord = strct_ops[0].calculate_coordination(**function_args)
+    coord = strct_ops[0].calculate_coordination(**cn_kwarks)
     assert (
-        strct_ops.structures._structures[0]._function_args["coordination"] == function_args
+        strct_ops.structures._structures[0]._function_args["coordination"] == cn_kwarks
     ), "Function parameters are wrong."
     assert (
         strct_ops.structures._structures[0]["extras"]["coordination"] == coord
     ), "Calculated extra is wrong."
-    assert strct_ops[0].calculate_coordination(**function_args) == coord, "Recalculation is wrong."
+    assert strct_ops[0].calculate_coordination(**cn_kwarks) == coord, "Recalculation is wrong."
 
-    function_args = {
+    cn_kwarks = {
         "symprec": 0.005,
         "angle_tolerance": -1.0,
         "hall_number": 0,
@@ -387,9 +387,9 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
         "return_primitive_structure": False,
         "return_standardized_structure": False,
     }
-    space_group = strct_ops[0].determine_space_group(**function_args)
+    space_group = strct_ops[0].determine_space_group(**cn_kwarks)
     assert (
-        strct_ops.structures._structures[0]._function_args["space_group"] == function_args
+        strct_ops.structures._structures[0]._function_args["space_group"] == cn_kwarks
     ), "Function parameters are wrong."
     assert (
         strct_ops.structures._structures[0]["attributes"]["space_group"]
@@ -399,12 +399,12 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
         strct_ops.structures._structures[0]["extras"]["space_group"] == space_group
     ), "Calculated extra is wrong."
     assert (
-        strct_ops[0].determine_space_group(**function_args) == space_group
+        strct_ops[0].determine_space_group(**cn_kwarks) == space_group
     ), "Recalculation is wrong."
-    function_args["return_sym_operations"] = False
-    space_group = strct_ops[0].determine_space_group(**function_args)
+    cn_kwarks["return_sym_operations"] = False
+    space_group = strct_ops[0].determine_space_group(**cn_kwarks)
     assert (
-        strct_ops.structures._structures[0]._function_args["space_group"] == function_args
+        strct_ops.structures._structures[0]._function_args["space_group"] == cn_kwarks
     ), "Function parameters are wrong."
     assert (
         strct_ops.structures._structures[0]["attributes"]["space_group"]
@@ -423,7 +423,7 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
     assert not strct_ops.structures._structures[
         1
     ].store_calculated_properties, "Setting `store_calculated_properties` to False not working."
-    space_group = strct_ops[1].determine_space_group(**function_args)
+    space_group = strct_ops[1].determine_space_group(**cn_kwarks)
     assert (
         strct_ops.structures._structures[1]._function_args == {}
     ), "Function parameters are wrong."


### PR DESCRIPTION
The function `add_structure_coord` and `determine_molecular_fragments` were very confusing due to the internal use of the `calculate_coordination` function. With this PR, the focus is on adding the structure and not the internally used `calculate_coordination` function.

In the same PR the default `method` is set to `atomic_radius` for `calculate_coordination`.