### PR TITLE
Fix external anylsis decorator and introduce ``cn_kwargs``.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,12 +29,14 @@ Version 0.3.0
 * Fix positions returned from ``strct.Structure.calculate_distance`` function (`PR #106 <https://github.com/aim2dat/aim2dat/pull/106>`_).
 * ``io.cif.read_file`` was not properly parsing string values in loops with delimiters ("" or '') and without spaces (`PR #118 <https://github.com/aim2dat/aim2dat/pull/118>`_).
 * Setting ``strct.Structure.site_attributes`` was not resetting the dictionary but instead adding the new key/value pairs (`PR #125 <https://github.com/aim2dat/aim2dat/pull/125>`_).
+* The ``strct.StructureOperations.compare_sites_via_coordination``, ``strct.StructureOperations.find_eq_sites_via_coordination``, ``strct.ext_analysis.decorator.external_analysis_method`` decorator now properly handles unset keyword arguments (`PR #128 <https://github.com/aim2dat/aim2dat/pull/128>`_).
 
 **Breaking Changes:**
 
 * ``strct.ext_analysis.determine_molecular_fragments`` now considers the same site multiple times if it is connected, returns a list of ``strct.Structure`` objects and does not shift the position of the first atom to zero (`PR #111 <https://github.com/aim2dat/aim2dat/pull/111>`_).
 * ``strct.ext_analysis.create_graph`` now only outputs the graphviz graph if the ``get_graphviz_graph`` parameter is set to ``True`` and networkx is added to the core dependencies (`PR #112 <https://github.com/aim2dat/aim2dat/pull/112>`_).
 * All units and constants now rely on an internal implementation which is based on CODATA 2022 instead of 2014 (`PR #122 <https://github.com/aim2dat/aim2dat/pull/122>`_).
+* The ``strct.ext_analysis.determine_molecular_fragments``, ``strct.ext_analysis.create_graph`` and ``strct.ext_manipulation.add_structure_coord`` functions now implement ``**cn_kwargs`` as container for the arguments forwarded to the ``strct.Structure.calculate_coordination`` function (`PR #128 <https://github.com/aim2dat/aim2dat/pull/128>`_).
 
 
 Version 0.2.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ Version 0.3.0
 * ``strct.ext_analysis.create_graph`` now only outputs the graphviz graph if the ``get_graphviz_graph`` parameter is set to ``True`` and networkx is added to the core dependencies (`PR #112 <https://github.com/aim2dat/aim2dat/pull/112>`_).
 * All units and constants now rely on an internal implementation which is based on CODATA 2022 instead of 2014 (`PR #122 <https://github.com/aim2dat/aim2dat/pull/122>`_).
 * The ``strct.ext_analysis.determine_molecular_fragments``, ``strct.ext_analysis.create_graph`` and ``strct.ext_manipulation.add_structure_coord`` functions now implement ``**cn_kwargs`` as container for the arguments forwarded to the ``strct.Structure.calculate_coordination`` function (`PR #128 <https://github.com/aim2dat/aim2dat/pull/128>`_).
+* The default value for the ``method`` parameter of the ``strct.Structure.calculate_coordination`` is now set to ``atomic_radius`` as this method seems more reliable and equally fast as ``minimum_distance`` (`PR #128 <https://github.com/aim2dat/aim2dat/pull/128>`_).
 
 
 Version 0.2.0

--- a/aim2dat/strct/ext_analysis/decorator.py
+++ b/aim2dat/strct/ext_analysis/decorator.py
@@ -17,14 +17,14 @@ def external_analysis_method(func):
 
     @wraps(func)
     def perform_strct_analysis(*args, **kwargs):
+        sig_pars = inspect.signature(func).parameters
         func_args = {}
-        for idx, (name, p0) in enumerate(inspect.signature(func).parameters.items()):
-            if idx < len(args):
-                func_args[name] = args[idx]
-                if name in kwargs:
-                    raise TypeError(f"{func.__name__}() got multiple values for argument '{name}'")
-            elif name in kwargs:
-                func_args[name] = kwargs[name]
+        for idx, arg in enumerate(args):
+            func_args[list(sig_pars.keys())[idx]] = arg
+        func_args.update(kwargs)
+        for keyw, par in sig_pars.items():
+            if keyw not in func_args and par.default is not par.empty:
+                func_args[keyw] = par.default
         structure = func_args.pop("structure")
         return _check_calculated_properties(structure, func, func_args)
 

--- a/aim2dat/strct/ext_analysis/fragmentation.py
+++ b/aim2dat/strct/ext_analysis/fragmentation.py
@@ -18,17 +18,7 @@ def determine_molecular_fragments(
     exclude_elements: List[str] = None,
     exclude_sites: List[int] = None,
     end_point_elements: List[str] = None,
-    r_max: float = 10.0,
-    cn_method: str = "minimum_distance",
-    min_dist_delta: float = 0.1,
-    n_nearest_neighbours: int = 5,
-    radius_type: str = "chen_manz",
-    atomic_radius_delta: float = 0.0,
-    econ_tolerance: float = 0.5,
-    econ_conv_threshold: float = 0.001,
-    voronoi_weight_type: float = "rel_solid_angle",
-    voronoi_weight_threshold: float = 0.5,
-    okeeffe_weight_threshold: float = 0.5,
+    **cn_kwargs,
 ) -> List[Structure]:
     """
     Find molecular fragments in a larger molecule/cluster of periodic crystal.
@@ -47,31 +37,8 @@ def determine_molecular_fragments(
         List of elements that serve as an end point for a fragment.
     r_max : float (optional)
         Cut-off value for the maximum distance between two atoms in angstrom.
-    cn_method : str (optional)
-        Method used to calculate the coordination environment.
-    min_dist_delta : float (optional)
-        Tolerance parameter that defines the relative distance from the nearest neighbour atom
-        for the ``'minimum_distance'`` method.
-    n_nearest_neighbours : int (optional)
-        Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-        method.
-    radius_type : str (optional)
-        Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-        used as fallback in the radius for an element is not defined).
-    atomic_radius_delta : float (optional)
-        Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-        If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-        positive (negative) values increase (decrease) the threshold.
-    econ_tolerance : float (optional)
-        Tolerance parameter for the econ method.
-    econ_conv_threshold : float (optional)
-        Convergence threshold for the econ method.
-    voronoi_weight_type : str (optional)
-        Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-        ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-        weights with respect to the maximum value of the polyhedron are calculated.
-    voronoi_weight_threshold : float (optional)
-        Weight threshold to consider a neighbouring atom coordinated.
+    cn_kwargs :
+        Optional keyword arguments passed on to the ``calculate_coordination`` function.
 
     Returns
     -------
@@ -86,19 +53,7 @@ def determine_molecular_fragments(
         end_point_elements = []
     used_site_indices = []
     molecular_fragments = []
-    coord = structure.calculate_coordination(
-        r_max=r_max,
-        method=cn_method,
-        min_dist_delta=min_dist_delta,
-        n_nearest_neighbours=n_nearest_neighbours,
-        radius_type=radius_type,
-        atomic_radius_delta=atomic_radius_delta,
-        econ_tolerance=econ_tolerance,
-        econ_conv_threshold=econ_conv_threshold,
-        voronoi_weight_type=voronoi_weight_type,
-        voronoi_weight_threshold=voronoi_weight_threshold,
-        okeeffe_weight_threshold=okeeffe_weight_threshold,
-    )
+    coord = structure.calculate_coordination(**cn_kwargs)
 
     allowed_sites = []
     for site_idx, el in enumerate(structure.elements):

--- a/aim2dat/strct/ext_analysis/graphs.py
+++ b/aim2dat/strct/ext_analysis/graphs.py
@@ -18,16 +18,7 @@ def create_graph(
     get_graphviz_graph: bool = False,
     graphviz_engine: str = "circo",
     graphviz_edge_rank_colors: List[str] = ["blue", "red", "green", "orange", "darkblue"],
-    r_max: float = 10.0,
-    cn_method: str = "minimum_distance",
-    min_dist_delta: float = 0.1,
-    n_nearest_neighbours: int = 5,
-    radius_type: str = "chen_manz",
-    atomic_radius_delta: float = 0.0,
-    econ_tolerance: float = 0.5,
-    econ_conv_threshold: float = 0.001,
-    voronoi_weight_type: float = "rel_solid_angle",
-    voronoi_weight_threshold: float = 0.5,
+    **cn_kwargs,
 ):
     """
     Create graph based on the coordination.
@@ -42,35 +33,8 @@ def create_graph(
         Graphviz engine used to create the graph. The default value is ``'circo'``.
     graphviz_edge_rank_colors : list
         List of colors of the different edge ranks.
-    r_max : float
-        Cut-off value for the maximum distance between two atoms in angstrom. The default
-        value is set to ``20.0``.
-    cn_method : str
-        Method used to calculate the coordination environment. The default value is
-        ``'minimum_distance'``.
-    min_dist_delta : float
-        Tolerance parameter that defines the relative distance from the nearest neighbour atom
-        for the ``'minimum_distance'`` method. The default value is ``0.1``.
-    n_nearest_neighbours : int
-        Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-        method. The default value is ``5``.
-    radius_type : str (optional)
-        Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-        used as fallback in the radius for an element is not defined).
-    atomic_radius_delta : float (optional)
-        Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-        If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-        positive (negative) values increase (decrease) the threshold.
-    econ_tolerance : float
-        Tolerance parameter for the econ method. The default value is ``0.5``.
-    econ_conv_threshold : float
-        Convergence threshold for the econ method. The default value is ``0.001``.
-    voronoi_weight_type : str (optional)
-        Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-        ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-        weights with respect to the maximum value of the polyhedron are calculated.
-    voronoi_weight_threshold : float (optional)
-        Weight threshold to consider a neighbouring atom coordinated.
+    cn_kwargs :
+        Optional keyword arguments passed on to the ``calculate_coordination`` function.
 
     Returns
     -------
@@ -79,18 +43,7 @@ def create_graph(
     graphviz_graph : graphviz.Digraph
         graphviz graph of the structure (if ``get_graphviz_graph`` is set to ``True``).
     """
-    coord = structure.calculate_coordination(
-        r_max=r_max,
-        method=cn_method,
-        min_dist_delta=min_dist_delta,
-        n_nearest_neighbours=n_nearest_neighbours,
-        radius_type=radius_type,
-        atomic_radius_delta=atomic_radius_delta,
-        econ_tolerance=econ_tolerance,
-        econ_conv_threshold=econ_conv_threshold,
-        voronoi_weight_type=voronoi_weight_type,
-        voronoi_weight_threshold=voronoi_weight_threshold,
-    )
+    coord = structure.calculate_coordination(**cn_kwargs)
     nx_graph = nx.MultiDiGraph()
     for site_idx, site in enumerate(coord["sites"]):
         nx_graph.add_node(site_idx, element=site["element"])

--- a/aim2dat/strct/ext_analysis/graphs.py
+++ b/aim2dat/strct/ext_analysis/graphs.py
@@ -48,6 +48,8 @@ def create_graph(
     for site_idx, site in enumerate(coord["sites"]):
         nx_graph.add_node(site_idx, element=site["element"])
     for site_idx, site in enumerate(coord["sites"]):
+        if len(site["neighbours"]) == 0:
+            continue
         distances = [neigh["distance"] for neigh in site["neighbours"]]
         zipped = list(zip(distances, range(len(site["neighbours"]))))
         zipped.sort(key=lambda point: point[0])

--- a/aim2dat/strct/ext_manipulation/decorator.py
+++ b/aim2dat/strct/ext_manipulation/decorator.py
@@ -15,15 +15,16 @@ def external_manipulation_method(func):
         """Wrap manipulation method and create output."""
         sig_pars = inspect.signature(func).parameters
         extracted_args = []
-        for key, pos in [("structure", 0), ("change_label", len(sig_pars) - 1)]:
-            if key in kwargs:
+        for key in ["structure", "change_label"]:
+            if key not in sig_pars:
+                raise TypeError(f"`{key}` not in function arguments.")
+            idx = list(sig_pars.keys()).index(key)
+            if idx < len(args):
+                extracted_args.append(args[idx])
+            elif key in kwargs:
                 extracted_args.append(kwargs[key])
-            elif len(args) > pos:
-                extracted_args.append(args[pos])
-            elif key in sig_pars:
-                extracted_args.append(sig_pars[key].default)
             else:
-                raise TypeError(f"'{key}' not in arguments.")
+                extracted_args.append(sig_pars[key].default)
 
         output = func(*args, **kwargs)
         if output is not None:

--- a/aim2dat/strct/mixin.py
+++ b/aim2dat/strct/mixin.py
@@ -290,7 +290,7 @@ class AnalysisMixin:
     def calculate_coordination(
         self,
         r_max: float = 10.0,
-        method: str = "minimum_distance",
+        method: str = "atomic_radius",
         min_dist_delta: float = 0.1,
         n_nearest_neighbours: int = 5,
         radius_type: str = "chen_manz",
@@ -309,8 +309,7 @@ class AnalysisMixin:
         r_max : float (optional)
             Cut-off value for the maximum distance between two atoms in angstrom.
         method : str (optional)
-            Method used to calculate the coordination environment. The default value is
-            ``'minimum_distance'``.
+            Method used to calculate the coordination environment.
         min_dist_delta : float (optional)
             Tolerance parameter that defines the relative distance from the nearest neighbour atom
             for the ``'minimum_distance'`` method.

--- a/aim2dat/strct/strct.py
+++ b/aim2dat/strct/strct.py
@@ -36,6 +36,9 @@ from aim2dat.utils.maths import calc_angle
 
 def _compare_function_args(args1, args2):
     """Compare function arguments to check if a property needs to be recalculated."""
+    if len(args1) != len(args2):
+        return False
+
     for kwarg, value1 in args1.items():
         if value1 != args2[kwarg]:
             return False

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -723,19 +723,9 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         key2: Union[str, int],
         site_index1: int,
         site_index2: int,
-        r_max: float = 10.0,
-        cn_method: str = "minimum_distance",
-        min_dist_delta: float = 0.1,
-        n_nearest_neighbours: int = 5,
-        radius_type: str = "chen_manz",
-        atomic_radius_delta: float = 0.0,
-        econ_tolerance: float = 0.5,
-        econ_conv_threshold: float = 0.001,
-        voronoi_weight_type: float = "rel_solid_angle",
-        voronoi_weight_threshold: float = 0.5,
-        okeeffe_weight_threshold: float = 0.5,
         distinguish_kinds: bool = False,
         threshold: float = 1e-2,
+        **cn_kwargs,
     ):
         """
         Compare two atomic sites based on their coordination and the distances to their neighbour
@@ -751,57 +741,19 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
             Index of the site.
         site_index2 : int
             Index of the site.
-        r_max : float (optional)
-            Cut-off value for the maximum distance between two atoms in angstrom.
-        cn_method : str (optional)
-            Method used to calculate the coordination environment.
-        min_dist_delta : float (optional)
-            Tolerance parameter that defines the relative distance from the nearest neighbour atom
-            for the ``'minimum_distance'`` method.
-        n_nearest_neighbours : int (optional)
-            Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-            method.
-        radius_type : str (optional)
-            Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-            used as fallback in the radius for an element is not defined).
-        atomic_radius_delta : float (optional)
-            Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-            If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-            positive (negative) values increase (decrease) the threshold.
-        econ_tolerance : float (optional)
-            Tolerance parameter for the econ method.
-        econ_conv_threshold : float (optional)
-            Convergence threshold for the econ method.
-        voronoi_weight_type : str (optional)
-            Weight type of the Voronoi facets. Supported options are ``'covalent_atomic_radius'``,
-            ``'area'`` and ``'solid_angle'``. The prefix ``'rel_'`` specifies that the relative
-            weights with respect to the maximum value of the polyhedron are calculated.
-        voronoi_weight_threshold : float (optional)
-            Weight threshold to consider a neighbouring atom coordinated.
-        okeeffe_weight_threshold : float (optional)
-            Threshold parameter to distinguish indirect and direct neighbour atoms for the
-            ``'okeeffe'``.
         distinguish_kinds: bool (optional)
             Whether different kinds should be distinguished e.g. Ni0 and Ni1 would be considered as
             different elements if ``True``.
         threshold : float (optional)
             Threshold to consider two sites equivalent.
+        cn_kwargs :
+            Optional keyword arguments passed on to the ``calculate_coordination`` function.
 
         Returns
         -------
         bool
             Whether the two sites are equivalent or not.
         """
-        calc_f_kwargs = {
-            "r_max": r_max,
-            "method": cn_method,
-            "min_dist_delta": min_dist_delta,
-            "econ_tolerance": econ_tolerance,
-            "econ_conv_threshold": econ_conv_threshold,
-            "voronoi_weight_type": voronoi_weight_type,
-            "voronoi_weight_threshold": voronoi_weight_threshold,
-            "okeeffe_weight_threshold": okeeffe_weight_threshold,
-        }
         compare_f_kwargs = {
             "distinguish_kinds": distinguish_kinds,
             "threshold": threshold,
@@ -812,7 +764,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
             site_index1,
             site_index2,
             "calculate_coordination",
-            calc_f_kwargs,
+            cn_kwargs,
             _coordination_compare_sites,
             compare_f_kwargs,
         )
@@ -889,19 +841,9 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
     def find_eq_sites_via_coordination(
         self,
         key: Union[str, int],
-        r_max: float = 10.0,
-        cn_method: str = "minimum_distance",
-        min_dist_delta: float = 0.1,
-        n_nearest_neighbours: int = 5,
-        radius_type: str = "chen_manz",
-        atomic_radius_delta: float = 0.0,
-        econ_tolerance: float = 0.5,
-        econ_conv_threshold: float = 0.001,
-        voronoi_weight_type: float = "rel_solid_angle",
-        voronoi_weight_threshold: float = 0.5,
-        okeeffe_weight_threshold: float = 0.5,
         distinguish_kinds: bool = False,
         threshold: float = 1e-2,
+        **cn_kwargs,
     ):
         """
         Find equivalent sites by comparing the coordination of each site and its distance to the
@@ -911,54 +853,22 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         ----------
         key : str or int
             Index or label of the structure.
-        r_max : float (optional)
-            Cut-off value for the maximum distance between two atoms in angstrom.
-        cn_method : str (optional)
-            Method used to calculate the coordination environment.
-        min_dist_delta : float (optional)
-            Tolerance parameter that defines the relative distance from the nearest neighbour atom
-            for the ``'minimum_distance'`` method.
-        n_nearest_neighbours : int (optional)
-            Number of neighbours that are considered coordinated for the ``'n_neighbours'``
-            method.
-        radius_type : str (optional)
-            Type of the atomic radius used for the ``'atomic_radius'`` method (``'covalent'`` is
-            used as fallback in the radius for an element is not defined).
-        atomic_radius_delta : float (optional)
-            Tolerance relative to the sum of the atomic radii for the ``'atomic_radius'`` method.
-            If set to ``0.0`` the maximum threshold is defined by the sum of the atomic radii,
-            positive (negative) values increase (decrease) the threshold.
-        econ_tolerance : float (optional)
-            Tolerance parameter for the econ method.
-        econ_conv_threshold : float (optional)
-            Convergence threshold for the econ method.
-        okeeffe_weight_threshold : float (optional)
-            Threshold parameter to distinguish indirect and direct neighbour atoms for the
-            ``'okeeffe'``.
         distinguish_kinds: bool (optional)
             Whether different kinds should be distinguished e.g. Ni0 and Ni1 would be considered as
             different elements if ``True``.
         threshold : float (optional)
             Threshold to consider two sites equivalent.
+        cn_kwargs :
+            Optional keyword arguments passed on to the ``calculate_coordination`` function.
 
         Returns
         --------
         dict :
             Dictionary grouping equivalent sites.
         """
-        coord_kwargs = {
-            "r_max": r_max,
-            "cn_method": cn_method,
-            "min_dist_delta": min_dist_delta,
-            "econ_tolerance": econ_tolerance,
-            "econ_conv_threshold": econ_conv_threshold,
-            "voronoi_weight_type": voronoi_weight_type,
-            "voronoi_weight_threshold": voronoi_weight_threshold,
-            "okeeffe_weight_threshold": okeeffe_weight_threshold,
-            "threshold": threshold,
-        }
+        cn_kwargs["threshold"] = threshold
         return self._find_equivalent_sites(
-            key, self.compare_sites_via_coordination, coord_kwargs, None, distinguish_kinds
+            key, self.compare_sites_via_coordination, cn_kwargs, None, distinguish_kinds
         )
 
     def find_eq_sites_via_ffingerprint(

--- a/doc/source/stram-multiple_structures.ipynb
+++ b/doc/source/stram-multiple_structures.ipynb
@@ -571,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/tests/strct/eq_sites_analysis/ZIF-8_coordination.yaml
+++ b/tests/strct/eq_sites_analysis/ZIF-8_coordination.yaml
@@ -1,6 +1,6 @@
 function_args:
   r_max: 5.0
-  cn_method: "econ"
+  method: "econ"
   min_dist_delta: 0.1
   n_nearest_neighbours: 5
   econ_tolerance: 0.001

--- a/tests/strct/fragment_analysis/Benzene.yaml
+++ b/tests/strct/fragment_analysis/Benzene.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-- cn_method: atomic_radius
+- method: atomic_radius
   radius_type: chen_manz
   atomic_radius_delta: 0.0
 - - elements: ['C', 'C', 'C', 'C', 'C', 'C', 'H', 'H', 'H', 'H', 'H', 'H']

--- a/tests/strct/fragment_analysis/ZIF-8.yaml
+++ b/tests/strct/fragment_analysis/ZIF-8.yaml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 - exclude_elements: [Zn]
-  cn_method: atomic_radius
+  method: atomic_radius
   radius_type: chen_manz
   atomic_radius_delta: 0.0
 - - label:

--- a/tests/strct/fragment_analysis/ZIF-8_complex.yaml
+++ b/tests/strct/fragment_analysis/ZIF-8_complex.yaml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 - exclude_sites: [0, 5, 6, 11, 12, 13, 14, 18, 30, 39, 40, 41, 42]
-  cn_method: atomic_radius
+  method: atomic_radius
   radius_type: chen_manz
   atomic_radius_delta: 0.0
 - - label:

--- a/tests/strct/test_ext_analysis_functions.py
+++ b/tests/strct/test_ext_analysis_functions.py
@@ -44,7 +44,7 @@ def test_func_args_extraction():
     assert strct._function_args == {
         "coordination": {
             "r_max": 10.0,
-            "method": "minimum_distance",
+            "method": "atomic_radius",
             "min_dist_delta": 0.1,
             "n_nearest_neighbours": 5,
             "radius_type": "chen_manz",
@@ -87,7 +87,9 @@ def test_determine_molecular_fragments_function(
 def test_determine_graph(nested_dict_comparison):
     """Test creating a graph from a structure."""
     strct = Structure(**load_yaml_file(STRUCTURES_PATH + "GaAs_216_prim.yaml"))
-    nx_graph, graphviz_graph = create_graph(strct, get_graphviz_graph=True)
+    nx_graph, graphviz_graph = create_graph(
+        strct, get_graphviz_graph=True, method="minimum_distance"
+    )
     assert list(nx_graph.edges) == [
         (0, 1, 0),
         (0, 1, 1),

--- a/tests/strct/test_ext_analysis_functions.py
+++ b/tests/strct/test_ext_analysis_functions.py
@@ -15,6 +15,54 @@ STRUCTURES_PATH = os.path.dirname(__file__) + "/structures/"
 FRAG_PATH = os.path.dirname(__file__) + "/fragment_analysis/"
 
 
+def test_func_args_extraction():
+    """Test correct extraction of function arguments done by the decorator."""
+    strct = Structure(**load_yaml_file(STRUCTURES_PATH + "GaAs_216_prim.yaml"))
+    create_graph(strct, method="n_nearest_neighbours")
+    assert strct._function_args == {
+        "coordination": {
+            "r_max": 10.0,
+            "method": "n_nearest_neighbours",
+            "min_dist_delta": 0.1,
+            "n_nearest_neighbours": 5,
+            "radius_type": "chen_manz",
+            "atomic_radius_delta": 0.0,
+            "econ_tolerance": 0.5,
+            "econ_conv_threshold": 0.001,
+            "voronoi_weight_type": "rel_solid_angle",
+            "voronoi_weight_threshold": 0.5,
+            "okeeffe_weight_threshold": 0.5,
+        },
+        "graph": {
+            "method": "n_nearest_neighbours",
+            "get_graphviz_graph": False,
+            "graphviz_engine": "circo",
+            "graphviz_edge_rank_colors": ["blue", "red", "green", "orange", "darkblue"],
+        },
+    }
+    create_graph(strct)
+    assert strct._function_args == {
+        "coordination": {
+            "r_max": 10.0,
+            "method": "minimum_distance",
+            "min_dist_delta": 0.1,
+            "n_nearest_neighbours": 5,
+            "radius_type": "chen_manz",
+            "atomic_radius_delta": 0.0,
+            "econ_tolerance": 0.5,
+            "econ_conv_threshold": 0.001,
+            "voronoi_weight_type": "rel_solid_angle",
+            "voronoi_weight_threshold": 0.5,
+            "okeeffe_weight_threshold": 0.5,
+        },
+        "graph": {
+            "get_graphviz_graph": False,
+            "graphviz_engine": "circo",
+            "graphviz_edge_rank_colors": ["blue", "red", "green", "orange", "darkblue"],
+        },
+    }
+
+
 @pytest.mark.parametrize(
     "system, file_suffix, backend",
     [

--- a/tests/strct/test_structure_op_compare_functions.py
+++ b/tests/strct/test_structure_op_compare_functions.py
@@ -74,7 +74,12 @@ def test_compare_sites_via_coordination(
     strct_ops = StructureOperations(strct_collect)
     assert (
         strct_ops.compare_sites_via_coordination(
-            structure1, structure2, site_index1, site_index2, distinguish_kinds=distinguish_kinds
+            structure1,
+            structure2,
+            site_index1,
+            site_index2,
+            distinguish_kinds=distinguish_kinds,
+            method="minimum_distance",
         )
         == ref_value
     )

--- a/tests/strct/test_structure_op_structure_manipulation.py
+++ b/tests/strct/test_structure_op_structure_manipulation.py
@@ -70,6 +70,7 @@ def test_add_structure_coord(structure_comparison):
             "bond_length": 1.0,
             "change_label": False,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct = new_strct.perform_manipulation(
@@ -81,6 +82,7 @@ def test_add_structure_coord(structure_comparison):
             "bond_length": 1.1,
             "change_label": False,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct = new_strct.perform_manipulation(
@@ -90,6 +92,7 @@ def test_add_structure_coord(structure_comparison):
             "guest_structure": "COOH",
             "change_label": False,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct = new_strct.perform_manipulation(
@@ -99,6 +102,7 @@ def test_add_structure_coord(structure_comparison):
             "guest_structure": "NH2",
             "change_label": False,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct = new_strct.perform_manipulation(
@@ -108,6 +112,7 @@ def test_add_structure_coord(structure_comparison):
             "guest_structure": "NO2",
             "change_label": False,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct = new_strct.perform_manipulation(
@@ -118,6 +123,7 @@ def test_add_structure_coord(structure_comparison):
             "change_label": False,
             "dist_threshold": None,
             "guest_dir": [1.0, 0.0, 0.0],
+            "method": "minimum_distance",
         },
     )
     new_strct.set_positions(new_strct.positions, wrap=True)


### PR DESCRIPTION
This PR implements:

-  bugfix where the external analysis decorator didn't extract unset keyword arguments.
-  ``cn_kwargs`` as a container for arguments for the ``strct.Structure.calculate_coordination`` function to facilitate maintenance.