### PR TITLE
Add `numbers` property to `Structure` object to return list of atomic numbers.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Version 0.3.0
 * Implemented BSSE parsing to ``io.cp2k.read_stdout`` function (`PR #115 <https://github.com/aim2dat/aim2dat/pull/115>`_ and `PR #116 <https://github.com/aim2dat/aim2dat/pull/116>`_).
 * Added more units and fundamental constants to ``utils.units`` (`PR #122 <https://github.com/aim2dat/aim2dat/pull/122>`_).
 * The ``strct.Structure.calculate_angle`` and ``strct.Structure.calculate_dihedral_angle`` now supports lists and ``None`` as input (`PR #126 <https://github.com/aim2dat/aim2dat/pull/126>`_).
+* The ``strct.Structure`` class has now the property ``numbers`` to get the atomic number related to the element (`PR #130 <https://github.com/aim2dat/aim2dat/pull/130>`_).
 
 **Fixes:**
 

--- a/aim2dat/strct/strct.py
+++ b/aim2dat/strct/strct.py
@@ -32,7 +32,7 @@ from aim2dat.strct.mixin import AnalysisMixin, ManipulationMixin
 import aim2dat.utils.chem_formula as utils_cf
 import aim2dat.utils.print as utils_pr
 from aim2dat.utils.maths import calc_angle
-from aim2dat.utils.data import atomic_numbers
+from aim2dat.utils.element_properties import get_atomic_number
 
 
 def _compare_function_args(args1, args2):
@@ -272,7 +272,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
         self._elements = elements
         self._element_dict = _create_index_dict(elements)
         self._chem_formula = utils_cf.transform_list_to_dict(elements)
-        self._numbers = [atomic_numbers[el] for el in elements]
+        self._numbers = tuple(get_atomic_number(el) for el in elements)
 
     @property
     def chem_formula(self) -> dict:

--- a/aim2dat/strct/strct.py
+++ b/aim2dat/strct/strct.py
@@ -32,6 +32,7 @@ from aim2dat.strct.mixin import AnalysisMixin, ManipulationMixin
 import aim2dat.utils.chem_formula as utils_cf
 import aim2dat.utils.print as utils_pr
 from aim2dat.utils.maths import calc_angle
+from aim2dat.utils.data import atomic_numbers
 
 
 def _compare_function_args(args1, args2):
@@ -271,6 +272,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
         self._elements = elements
         self._element_dict = _create_index_dict(elements)
         self._chem_formula = utils_cf.transform_list_to_dict(elements)
+        self._numbers = [atomic_numbers[el] for el in elements]
 
     @property
     def chem_formula(self) -> dict:
@@ -278,6 +280,11 @@ class Structure(AnalysisMixin, ManipulationMixin):
         Return chemical formula.
         """
         return self._chem_formula
+
+    @property
+    def numbers(self) -> tuple:
+        """Return the atomic numbers of the structure."""
+        return self._numbers
 
     @property
     def positions(self) -> tuple:

--- a/aim2dat/utils/data/__init__.py
+++ b/aim2dat/utils/data/__init__.py
@@ -272,6 +272,3 @@ val_electrons = {
     "Ts": 7,
     "Og": 8,
 }
-
-
-atomic_numbers = {element: number + 1 for number, element in enumerate(val_electrons.keys())}

--- a/aim2dat/utils/data/__init__.py
+++ b/aim2dat/utils/data/__init__.py
@@ -272,3 +272,6 @@ val_electrons = {
     "Ts": 7,
     "Og": 8,
 }
+
+
+atomic_numbers = {element: number + 1 for number, element in enumerate(val_electrons.keys())}

--- a/tests/strct/test_structure.py
+++ b/tests/strct/test_structure.py
@@ -206,6 +206,7 @@ def test_structure_features():
             ), "Positions don't match."
     assert "positions" in structure
     assert structure["kinds"] == tuple(strct_dict["kinds"])
+    assert structure["numbers"] == (55, 55, 55, 55, 55, 55, 55, 55, 52, 52, 52, 52)
 
     with pytest.raises(ValueError) as error:
         structure.set_positions([[0.0, 0.0, 0.0]])
@@ -214,6 +215,8 @@ def test_structure_features():
 
 def test_list_methods():
     """Test listing different method categories."""
+    print(Structure)
+    print(Structure.import_methods)
     assert Structure.import_methods == [
         "from_file",
         "from_ase_atoms",

--- a/tests/strct/test_structure.py
+++ b/tests/strct/test_structure.py
@@ -215,8 +215,6 @@ def test_structure_features():
 
 def test_list_methods():
     """Test listing different method categories."""
-    print(Structure)
-    print(Structure.import_methods)
     assert Structure.import_methods == [
         "from_file",
         "from_ase_atoms",


### PR DESCRIPTION
This PR adds `numbers` as property to the `Structure` object to get atomic numbers. Also adds a dict in `data` where the key is the element with its corresponding atomic number.

Closes: #49 