### PR TITLE
Unify naming scheme of structural analysis methods and improve storage of calculated properties.

### DIFF
--- a/aim2dat/ext_interfaces/dscribe.py
+++ b/aim2dat/ext_interfaces/dscribe.py
@@ -55,7 +55,7 @@ def calc_interaction_matrix(
     output = matrix_obj.create(structure.to_ase_atoms(), **create_kwargs)
     if enforce_real:
         output = output.real
-    return None, output.tolist()
+    return output.tolist()
 
 
 def calc_acsf_descriptor(
@@ -147,11 +147,8 @@ def calc_mbtr_descriptor(
 
 def return_descriptor(obj, structure, dscribe_n_jobs, dscribe_only_physical_cores):
     """Return output from SOAP, MBTR or ACSF descriptor."""
-    return (
-        None,
-        obj.create(
-            structure.to_ase_atoms(),
-            n_jobs=dscribe_n_jobs,
-            only_physical_cores=dscribe_only_physical_cores,
-        ).tolist(),
-    )
+    return obj.create(
+        structure.to_ase_atoms(),
+        n_jobs=dscribe_n_jobs,
+        only_physical_cores=dscribe_only_physical_cores,
+    ).tolist()

--- a/aim2dat/ext_interfaces/spglib.py
+++ b/aim2dat/ext_interfaces/spglib.py
@@ -129,7 +129,7 @@ def _space_group_analysis(
             angle_tolerance=angle_tolerance,
         )
         output_dict["standardized_structure"] = _transform_cell_to_structure(std_cell)
-    return output_dict["space_group"]["number"], output_dict
+    return output_dict
 
 
 def _layer_group_analysis(

--- a/aim2dat/io/zeo.py
+++ b/aim2dat/io/zeo.py
@@ -11,7 +11,7 @@ def write_to_file(struct_dict, file_path):
         output.append(
             " ".join(map(str, struct_dict.cell_angles))
             + " SPGR = "
-            + struct_dict.determine_space_group()["space_group"]["international_short"]
+            + struct_dict.calc_space_group()["space_group"]["international_short"]
         )
         output.append(f"{len(struct_dict.positions)} 0")
         output.append(f"0 {struct_dict.label}")

--- a/aim2dat/ml/cell_grid_search.py
+++ b/aim2dat/ml/cell_grid_search.py
@@ -146,7 +146,7 @@ class CellGridSearch:
             List of parameter sets that are varied.
         """
         search_space = []
-        space_group = self._strct_ops["initial"].determine_space_group(
+        space_group = self._strct_ops["initial"].calc_space_group(
             symprec=self.symprec,
             angle_tolerance=self.angle_tolerance,
             hall_number=self.hall_number,
@@ -241,7 +241,7 @@ class CellGridSearch:
         """
         if search_space is None:
             search_space = self.return_search_space()
-        initial_sg = self._strct_ops["initial"].determine_space_group(
+        initial_sg = self._strct_ops["initial"].calc_space_group(
             symprec=self.symprec,
             angle_tolerance=self.angle_tolerance,
             hall_number=self.hall_number,
@@ -268,7 +268,7 @@ class CellGridSearch:
                 cell=cell,
                 is_cartesian=False,
             )
-            trial_sg = self._strct_ops[str(idx0)].determine_space_group(
+            trial_sg = self._strct_ops[str(idx0)].calc_space_group(
                 symprec=self.symprec,
                 angle_tolerance=self.angle_tolerance,
                 hall_number=self.hall_number,

--- a/aim2dat/ml/transformers.py
+++ b/aim2dat/ml/transformers.py
@@ -13,12 +13,12 @@ from sklearn.utils.validation import check_is_fitted
 # Internal library imports
 from aim2dat.strct import StructureCollection, StructureOperations
 from aim2dat.strct.ext_analysis import (
-    calculate_warren_cowley_order_p,
-    calculate_prdf,
-    calculate_interaction_matrix,
-    calculate_acsf_descriptor,
-    calculate_soap_descriptor,
-    calculate_mbtr_descriptor,
+    calc_warren_cowley_order_p,
+    calc_prdf,
+    calc_interaction_matrix,
+    calc_acsf_descriptor,
+    calc_soap_descriptor,
+    calc_mbtr_descriptor,
 )
 from aim2dat.strct.strct import _compare_function_args
 from aim2dat.utils.chem_formula import transform_list_to_dict
@@ -456,7 +456,7 @@ class StructureCoordinationTransformer(_BaseStructureTransformer):
         self._features_out = np.asarray(f_labels, dtype=object)
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].calculate_coordination(**input_p)
+        return strct_op[label_list].calc_coordination(**input_p)
 
     def _get_features(self, label_list, strct_op, input_p):
         check_is_fitted(self, attributes="el_pairs_")
@@ -518,7 +518,7 @@ class StructureChemOrderTransformer(_BaseStructureTransformer):
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
         return strct_op[label_list].perform_analysis(
-            method=calculate_warren_cowley_order_p, kwargs=input_p
+            method=calc_warren_cowley_order_p, kwargs=input_p
         )
 
     def _get_features(self, label_list, strct_op, input_p):
@@ -590,7 +590,7 @@ class StructureFFPrintTransformer(_BaseStructureTransformer):
         self.el_pairs_ = list(itertools.combinations_with_replacement(self.elements_, 2))
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].calculate_ffingerprint(**input_p)
+        return strct_op[label_list].calc_ffingerprint(**input_p)
 
     def _get_features(self, label_list, strct_op, input_p):
         check_is_fitted(self, attributes="el_pairs_")
@@ -666,7 +666,7 @@ class StructurePRDFTransformer(_BaseStructureTransformer):
         self.el_pairs_ = list(itertools.product(all_elements, repeat=2))
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].perform_analysis(method=calculate_prdf, kwargs=input_p)
+        return strct_op[label_list].perform_analysis(method=calc_prdf, kwargs=input_p)
 
     def _get_features(self, label_list, strct_op, input_p):
         check_is_fitted(self, attributes="el_pairs_")
@@ -787,7 +787,7 @@ class StructureMatrixTransformer(_BaseStructureTransformer):
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
         return strct_op[label_list].perform_analysis(
-            method=calculate_interaction_matrix, kwargs=input_p
+            method=calc_interaction_matrix, kwargs=input_p
         )
 
     def _get_features(self, label_list, strct_op, input_p):
@@ -878,9 +878,7 @@ class StructureACSFTransformer(_BaseDscribeTransformer):
         self.dscribe_only_physical_cores = dscribe_only_physical_cores
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].perform_analysis(
-            method=calculate_acsf_descriptor, kwargs=input_p
-        )
+        return strct_op[label_list].perform_analysis(method=calc_acsf_descriptor, kwargs=input_p)
 
 
 class StructureSOAPTransformer(_BaseDscribeTransformer):
@@ -976,9 +974,7 @@ class StructureSOAPTransformer(_BaseDscribeTransformer):
         self.dscribe_only_physical_cores = dscribe_only_physical_cores
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].perform_analysis(
-            method=calculate_soap_descriptor, kwargs=input_p
-        )
+        return strct_op[label_list].perform_analysis(method=calc_soap_descriptor, kwargs=input_p)
 
 
 class StructureMBTRTransformer(_BaseDscribeTransformer):
@@ -1060,6 +1056,4 @@ class StructureMBTRTransformer(_BaseDscribeTransformer):
         self.dscribe_only_physical_cores = dscribe_only_physical_cores
 
     def _get_strct_op_properties(self, label_list, strct_op, input_p):
-        return strct_op[label_list].perform_analysis(
-            method=calculate_mbtr_descriptor, kwargs=input_p
-        )
+        return strct_op[label_list].perform_analysis(method=calc_mbtr_descriptor, kwargs=input_p)

--- a/aim2dat/strct/ext_analysis/__init__.py
+++ b/aim2dat/strct/ext_analysis/__init__.py
@@ -3,34 +3,34 @@ Methods acting on a ``Structure`` object to calculate structural properties and 
 """
 
 from aim2dat.strct.ext_analysis.fragmentation import (
-    determine_molecular_fragments,
+    calc_molecular_fragments,
 )
-from aim2dat.strct.ext_analysis.graphs import create_graph
-from aim2dat.strct.ext_analysis.prdf import calculate_prdf
+from aim2dat.strct.ext_analysis.graphs import calc_graph
+from aim2dat.strct.ext_analysis.prdf import calc_prdf
 from aim2dat.strct.ext_analysis.ffprint_order_p import (
-    calculate_ffingerprint_order_p,
+    calc_ffingerprint_order_p,
 )
 from aim2dat.strct.ext_analysis.warren_cowley_order_parameters import (
-    calculate_warren_cowley_order_p,
+    calc_warren_cowley_order_p,
 )
-from aim2dat.strct.ext_analysis.planes import calculate_planes
+from aim2dat.strct.ext_analysis.planes import calc_planes
 from aim2dat.strct.ext_analysis.dscribe_descriptors import (
-    calculate_interaction_matrix,
-    calculate_acsf_descriptor,
-    calculate_soap_descriptor,
-    calculate_mbtr_descriptor,
+    calc_interaction_matrix,
+    calc_acsf_descriptor,
+    calc_soap_descriptor,
+    calc_mbtr_descriptor,
 )
 
 
 __all__ = [
-    "determine_molecular_fragments",
-    "create_graph",
-    "calculate_prdf",
-    "calculate_ffingerprint_order_p",
-    "calculate_warren_cowley_order_p",
-    "calculate_planes",
-    "calculate_interaction_matrix",
-    "calculate_acsf_descriptor",
-    "calculate_soap_descriptor",
-    "calculate_mbtr_descriptor",
+    "calc_molecular_fragments",
+    "calc_graph",
+    "calc_prdf",
+    "calc_ffingerprint_order_p",
+    "calc_warren_cowley_order_p",
+    "calc_planes",
+    "calc_interaction_matrix",
+    "calc_acsf_descriptor",
+    "calc_soap_descriptor",
+    "calc_mbtr_descriptor",
 ]

--- a/aim2dat/strct/ext_analysis/decorator.py
+++ b/aim2dat/strct/ext_analysis/decorator.py
@@ -10,23 +10,25 @@ from functools import wraps
 from aim2dat.strct.strct import _check_calculated_properties
 
 
-def external_analysis_method(func):
-    """
-    Decorate external analysis methods.
-    """
+def external_analysis_method(attr_mapping):
+    """Decorate external analysis methods."""
 
-    @wraps(func)
-    def perform_strct_analysis(*args, **kwargs):
-        sig_pars = inspect.signature(func).parameters
-        func_args = {}
-        for idx, arg in enumerate(args):
-            func_args[list(sig_pars.keys())[idx]] = arg
-        func_args.update(kwargs)
-        for keyw, par in sig_pars.items():
-            if keyw not in func_args and par.default is not par.empty:
-                func_args[keyw] = par.default
-        structure = func_args.pop("structure")
-        return _check_calculated_properties(structure, func, func_args)
+    def decorator(func):
+        func._is_analysis_method = True
 
-    perform_strct_analysis._is_analysis_method = True
-    return perform_strct_analysis
+        @wraps(func)
+        def perform_strct_analysis(*args, **kwargs):
+            sig_pars = inspect.signature(func).parameters
+            func_args = {}
+            for idx, arg in enumerate(args):
+                func_args[list(sig_pars.keys())[idx]] = arg
+            func_args.update(kwargs)
+            for keyw, par in sig_pars.items():
+                if keyw not in func_args and par.default is not par.empty:
+                    func_args[keyw] = par.default
+            structure = func_args.pop("structure")
+            return _check_calculated_properties(structure, func, func_args, attr_mapping)
+
+        return perform_strct_analysis
+
+    return decorator

--- a/aim2dat/strct/ext_analysis/dscribe_descriptors.py
+++ b/aim2dat/strct/ext_analysis/dscribe_descriptors.py
@@ -9,8 +9,8 @@ from aim2dat.strct.strct import Structure
 from aim2dat.strct.ext_analysis.decorator import external_analysis_method
 
 
-@external_analysis_method
-def calculate_interaction_matrix(
+@external_analysis_method(attr_mapping=None)
+def calc_interaction_matrix(
     structure: Structure,
     matrix_type: str = "coulomb",
     n_atoms_max: int = None,
@@ -87,8 +87,8 @@ def calculate_interaction_matrix(
     )
 
 
-@external_analysis_method
-def calculate_acsf_descriptor(
+@external_analysis_method(attr_mapping=None)
+def calc_acsf_descriptor(
     structure: Structure,
     r_cut: float = 7.5,
     g2_params: list = None,
@@ -150,8 +150,8 @@ def calculate_acsf_descriptor(
     )
 
 
-@external_analysis_method
-def calculate_soap_descriptor(
+@external_analysis_method(attr_mapping=None)
+def calc_soap_descriptor(
     structure: Structure,
     r_cut: float = 7.5,
     n_max: list = 8,
@@ -227,8 +227,8 @@ def calculate_soap_descriptor(
     )
 
 
-@external_analysis_method
-def calculate_mbtr_descriptor(
+@external_analysis_method(attr_mapping=None)
+def calc_mbtr_descriptor(
     structure: Structure,
     geometry: dict = {"function": "inverse_distance"},
     grid: dict = {"min": 0, "max": 1, "n": 100, "sigma": 0.1},

--- a/aim2dat/strct/ext_analysis/ffprint_order_p.py
+++ b/aim2dat/strct/ext_analysis/ffprint_order_p.py
@@ -12,8 +12,8 @@ from aim2dat.strct.ext_analysis.decorator import external_analysis_method
 from aim2dat.strct.strct_prdf import _calculate_weights
 
 
-@external_analysis_method
-def calculate_ffingerprint_order_p(
+@external_analysis_method(attr_mapping={"ffingerprint_order_p": ("el_order_p",)})
+def calc_ffingerprint_order_p(
     structure: Structure,
     r_max: float = 15.0,
     delta_bin: float = 0.005,
@@ -54,7 +54,7 @@ def calculate_ffingerprint_order_p(
             order_p += prefactor * np.linalg.norm(np.array(fprint["fingerprints"][el_pair])) ** 2
         return order_p
 
-    fprints = structure.calculate_ffingerprint(
+    fprints = structure.calc_ffingerprint(
         r_max=r_max, delta_bin=delta_bin, sigma=sigma, distinguish_kinds=distinguish_kinds
     )
 
@@ -68,4 +68,4 @@ def calculate_ffingerprint_order_p(
     site_order_p = [
         _calc_order_p(delta_bin, fprint, weights, cell_v, n_atoms) for fprint in fprints[1]
     ]
-    return el_order_p, (el_order_p, site_order_p)
+    return {"order_p": el_order_p, "site_order_p": site_order_p}

--- a/aim2dat/strct/ext_analysis/fragmentation.py
+++ b/aim2dat/strct/ext_analysis/fragmentation.py
@@ -11,8 +11,8 @@ from aim2dat.strct.strct import Structure
 from aim2dat.strct.ext_analysis.decorator import external_analysis_method
 
 
-@external_analysis_method
-def determine_molecular_fragments(
+@external_analysis_method(attr_mapping=None)
+def calc_molecular_fragments(
     structure: Structure,
     max_fragment_size: int = 100,
     exclude_elements: List[str] = None,
@@ -53,7 +53,7 @@ def determine_molecular_fragments(
         end_point_elements = []
     used_site_indices = []
     molecular_fragments = []
-    coord = structure.calculate_coordination(**cn_kwargs)
+    coord = structure.calc_coordination(**cn_kwargs)
 
     allowed_sites = []
     for site_idx, el in enumerate(structure.elements):
@@ -84,7 +84,7 @@ def determine_molecular_fragments(
         if mol_fragment["elements"] != []:
             molecular_fragments.append(Structure(**mol_fragment))
             used_site_indices += mol_fragment["site_attributes"]["parent_indices"]
-    return None, molecular_fragments
+    return molecular_fragments
 
 
 def _recursive_graph_builder(

--- a/aim2dat/strct/ext_analysis/graphs.py
+++ b/aim2dat/strct/ext_analysis/graphs.py
@@ -12,8 +12,8 @@ from aim2dat.strct.strct import Structure
 from aim2dat.strct.ext_analysis.decorator import external_analysis_method
 
 
-@external_analysis_method
-def create_graph(
+@external_analysis_method(attr_mapping=None)
+def calc_graph(
     structure: Structure,
     get_graphviz_graph: bool = False,
     graphviz_engine: str = "circo",
@@ -43,7 +43,7 @@ def create_graph(
     graphviz_graph : graphviz.Digraph
         graphviz graph of the structure (if ``get_graphviz_graph`` is set to ``True``).
     """
-    coord = structure.calculate_coordination(**cn_kwargs)
+    coord = structure.calc_coordination(**cn_kwargs)
     nx_graph = nx.MultiDiGraph()
     for site_idx, site in enumerate(coord["sites"]):
         nx_graph.add_node(site_idx, element=site["element"])
@@ -65,11 +65,8 @@ def create_graph(
 
     if get_graphviz_graph:
         backend_module = _return_ext_interface_modules("graphviz")
-        return None, (
-            nx_graph,
-            backend_module._networkx2graphviz(
-                nx_graph, graphviz_engine, graphviz_edge_rank_colors
-            ),
+        return nx_graph, backend_module._networkx2graphviz(
+            nx_graph, graphviz_engine, graphviz_edge_rank_colors
         )
     else:
-        return None, nx_graph
+        return nx_graph

--- a/aim2dat/strct/ext_analysis/planes.py
+++ b/aim2dat/strct/ext_analysis/planes.py
@@ -16,8 +16,8 @@ from aim2dat.utils.maths import calc_plane_equation
 from aim2dat.strct.strct_super_cell import _create_supercell_positions
 
 
-@external_analysis_method
-def calculate_planes(
+@external_analysis_method(attr_mapping=None)
+def calc_planes(
     structure: Structure,
     r_max: float = 15.0,
     fragment: list = None,
@@ -124,7 +124,7 @@ def calculate_planes(
                 for pl0 in plane["plane"]
             ]
         planes.append(plane)
-    return None, planes
+    return planes
 
 
 def _construct_orthogonal_plane(plane_group, positions, elements, mapping, margin, vector_lengths):

--- a/aim2dat/strct/ext_analysis/prdf.py
+++ b/aim2dat/strct/ext_analysis/prdf.py
@@ -9,8 +9,8 @@ from aim2dat.strct.ext_analysis.decorator import external_analysis_method
 from aim2dat.strct.strct_prdf import _calculate_prdf
 
 
-@external_analysis_method
-def calculate_prdf(
+@external_analysis_method(attr_mapping=None)
+def calc_prdf(
     structure: Structure,
     r_max: float = 20.0,
     delta_bin: float = 0.005,
@@ -49,4 +49,4 @@ def calculate_prdf(
     for idx, prdfs in enumerate(atomic_prdf):
         for el_pair, prdf in prdfs.items():
             atomic_prdf[idx][el_pair] = prdf.tolist()
-    return None, (element_prdf, atomic_prdf)
+    return (element_prdf, atomic_prdf)

--- a/aim2dat/strct/ext_analysis/warren_cowley_order_parameters.py
+++ b/aim2dat/strct/ext_analysis/warren_cowley_order_parameters.py
@@ -10,10 +10,8 @@ from aim2dat.strct.strct import Structure
 from aim2dat.utils.maths import calc_polygon_area
 
 
-@external_analysis_method
-def calculate_warren_cowley_order_p(
-    structure: Structure, r_max: float = 20.0, max_shells: int = 3
-):
+@external_analysis_method(attr_mapping=None)
+def calc_warren_cowley_order_p(structure: Structure, r_max: float = 20.0, max_shells: int = 3):
     """
     Calculate Warren-Cowley like order parameters as defined in :doi:`10.1103/PhysRevB.96.024104`.
 
@@ -32,7 +30,7 @@ def calculate_warren_cowley_order_p(
         Dictionary containing the order parameters.
     """
     # TODO calculate in voronoi tessellation? and implement different weights
-    voronoi_list = structure.calculate_voronoi_tessellation(r_max)
+    voronoi_list = structure.calc_voronoi_tessellation(r_max)
     for vlist_site in voronoi_list:
         for vinfo in vlist_site:
             vinfo["weight"] = calc_polygon_area(vinfo["vertices"])
@@ -42,7 +40,7 @@ def calculate_warren_cowley_order_p(
     order_p_list = []
 
     if len(kind_dict) == 1:
-        return None, {
+        return {
             "order_p": {kinds[0]: [0.0 for _ in range(max_shells)]},
             "order_p_sites": [[0.0 for _ in range(max_shells)] for _ in kinds],
         }
@@ -69,7 +67,7 @@ def calculate_warren_cowley_order_p(
         order_p_dict[kind] = [
             mean(order_p_list[idx][shell] for idx in kind_sites) for shell in range(max_shells)
         ]
-    return None, {"order_p": order_p_dict, "order_p_sites": order_p_list}
+    return {"order_p": order_p_dict, "order_p_sites": order_p_list}
 
 
 def _calculate_order_p_recursive(

--- a/aim2dat/strct/ext_manipulation/add_structure.py
+++ b/aim2dat/strct/ext_manipulation/add_structure.py
@@ -188,7 +188,7 @@ def add_structure_coord(
     change_label : bool (optional)
         Add suffix to the label of the new structure highlighting the performed manipulation.
     cn_kwargs :
-        Optional keyword arguments passed on to the ``calculate_coordination`` function.
+        Optional keyword arguments passed on to the ``calc_coordination`` function.
 
     Returns
     -------
@@ -223,12 +223,12 @@ def add_structure_coord(
         guest_dir = [1.0, 0.0, 0.0]
         if len(guest_strct) > 1:
             # Get vector of guest atoms for rotation
-            guest_strct_coord = guest_strct.calculate_coordination(**cn_kwargs)
+            guest_strct_coord = guest_strct.calc_coordination(**cn_kwargs)
             guest_dir = -1.0 * _derive_bond_dir(guest_index, guest_strct_coord)
     guest_dir /= np.linalg.norm(np.array(guest_dir))
 
     # Calculate coordination:
-    coord = structure.calculate_coordination(**cn_kwargs)
+    coord = structure.calc_coordination(**cn_kwargs)
 
     # Derive bond directions and rotation to align guest towards bond direction:
     bond_dir = _derive_bond_dir(host_indices[0], coord)
@@ -477,9 +477,7 @@ def _add_mol(
         host_indices = [idx for idx, _, _ in dist_constraints]
         guest_indices = [idx + len(structure) for _, idx, _ in dist_constraints]
         ref_dists = [dist for _, _, dist in dist_constraints]
-        dists = new_structure.calculate_distance(
-            host_indices, guest_indices, backfold_positions=True
-        )
+        dists = new_structure.calc_distance(host_indices, guest_indices, backfold_positions=True)
         if isinstance(dists, float):
             dists = [dists]
         elif isinstance(dists, dict):

--- a/aim2dat/strct/ext_manipulation/utils.py
+++ b/aim2dat/strct/ext_manipulation/utils.py
@@ -121,7 +121,7 @@ def _check_distances(
 
     # Calculate pair-wise distances:
     other_indices = [i for i in range(len(structure)) if i not in indices]
-    dists = structure.calculate_distance(other_indices, indices, backfold_positions=True)
+    dists = structure.calc_distance(other_indices, indices, backfold_positions=True)
 
     for idx_pair, dist in dists.items():
         threshold = distance_dict.get(tuple(sorted(idx_pair)), None)

--- a/aim2dat/strct/mixin.py
+++ b/aim2dat/strct/mixin.py
@@ -6,19 +6,20 @@ from typing import List, Tuple, Union
 import abc
 from typing import TYPE_CHECKING
 from collections.abc import Callable
+from functools import wraps
 
 # Internal library imports
 import aim2dat.utils.chem_formula as utils_cf
 from aim2dat.strct.strct_point_groups import determine_point_group
 from aim2dat.strct.strct_space_groups import determine_space_group
 from aim2dat.strct.strct_misc import (
-    calculate_distance,
-    calculate_angle,
-    calculate_dihedral_angle,
+    calc_distance,
+    calc_angle,
+    calc_dihedral_angle,
 )
-from aim2dat.strct.strct_coordination import calculate_coordination
-from aim2dat.strct.strct_super_cell import calculate_voronoi_tessellation
-from aim2dat.strct.strct_prdf import calculate_ffingerprint
+from aim2dat.strct.strct_coordination import calc_coordination
+from aim2dat.strct.strct_super_cell import calc_voronoi_tessellation
+from aim2dat.strct.strct_prdf import calc_ffingerprint
 from aim2dat.strct.strct_manipulation import (
     create_supercell,
     delete_atoms,
@@ -52,8 +53,9 @@ class classproperty:
 
 
 def analysis_method(func):
-    """Mark function as calculation function."""
+    """Mark internal structure analysis functions."""
 
+    @wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
@@ -64,6 +66,7 @@ def analysis_method(func):
 def manipulates_structure(func):
     """Mark structure manipulating functions."""
 
+    @wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
@@ -98,7 +101,7 @@ class AnalysisMixin:
         return cls.list_analysis_methods()
 
     @analysis_method
-    def determine_point_group(
+    def calc_point_group(
         self,
         threshold_distance: float = 0.1,
         threshold_angle: float = 1.0,
@@ -126,10 +129,12 @@ class AnalysisMixin:
             "threshold_angle": threshold_angle,
             "threshold_inertia": threshold_inertia,
         }
-        return self._perform_strct_analysis(determine_point_group, kwargs)
+        return self._perform_strct_analysis(
+            determine_point_group, kwargs, mapping={"point_group": ("point_group",)}
+        )
 
     @analysis_method
-    def determine_space_group(
+    def calc_space_group(
         self,
         symprec: float = 0.005,
         angle_tolerance: float = -1.0,
@@ -174,10 +179,12 @@ class AnalysisMixin:
             "return_standardized_structure": return_standardized_structure,
             "no_idealize": no_idealize,
         }
-        return self._perform_strct_analysis(determine_space_group, kwargs)
+        return self._perform_strct_analysis(
+            determine_space_group, kwargs, mapping={"space_group": ("space_group", "number")}
+        )
 
     @analysis_method
-    def calculate_distance(
+    def calc_distance(
         self,
         site_index1: Union[int, List[int]] = 0,
         site_index2: Union[int, List[int]] = 1,
@@ -223,10 +230,10 @@ class AnalysisMixin:
             "r_max": r_max,
             "return_pos": return_pos,
         }
-        return self._perform_strct_analysis(calculate_distance, kwargs)
+        return self._perform_strct_analysis(calc_distance, kwargs)
 
     @analysis_method
-    def calculate_angle(
+    def calc_angle(
         self,
         site_index1: Union[int, List[int]] = 0,
         site_index2: Union[int, List[int]] = 1,
@@ -260,10 +267,10 @@ class AnalysisMixin:
             "site_index3": site_index3,
             "backfold_positions": backfold_positions,
         }
-        return self._perform_strct_analysis(calculate_angle, kwargs)
+        return self._perform_strct_analysis(calc_angle, kwargs)
 
     @analysis_method
-    def calculate_dihedral_angle(
+    def calc_dihedral_angle(
         self,
         site_index1: Union[int, List[int]] = 0,
         site_index2: Union[int, List[int]] = 1,
@@ -300,10 +307,10 @@ class AnalysisMixin:
             "site_index4": site_index4,
             "backfold_positions": backfold_positions,
         }
-        return self._perform_strct_analysis(calculate_dihedral_angle, kwargs)
+        return self._perform_strct_analysis(calc_dihedral_angle, kwargs)
 
     @analysis_method
-    def calculate_voronoi_tessellation(
+    def calc_voronoi_tessellation(
         self,
         r_max: float = 10.0,
     ) -> List[List[dict]]:
@@ -320,10 +327,10 @@ class AnalysisMixin:
         list
             List of voronoi details for each atomic site.
         """
-        return self._perform_strct_analysis(calculate_voronoi_tessellation, {"r_max": r_max})
+        return self._perform_strct_analysis(calc_voronoi_tessellation, {"r_max": r_max})
 
     @analysis_method
-    def calculate_coordination(
+    def calc_coordination(
         self,
         r_max: float = 10.0,
         method: str = "atomic_radius",
@@ -395,10 +402,10 @@ class AnalysisMixin:
             "voronoi_weight_threshold": voronoi_weight_threshold,
             "okeeffe_weight_threshold": okeeffe_weight_threshold,
         }
-        return self._perform_strct_analysis(calculate_coordination, kwargs)
+        return self._perform_strct_analysis(calc_coordination, kwargs)
 
     @analysis_method
-    def calculate_ffingerprint(
+    def calc_ffingerprint(
         self,
         r_max: float = 20.0,
         delta_bin: float = 0.005,
@@ -440,10 +447,10 @@ class AnalysisMixin:
             "distinguish_kinds": distinguish_kinds,
             "use_legacy_smearing": use_legacy_smearing,
         }
-        return self._perform_strct_analysis(calculate_ffingerprint, kwargs)
+        return self._perform_strct_analysis(calc_ffingerprint, kwargs)
 
     @abc.abstractmethod
-    def _perform_strct_analysis(self, method, kwargs):
+    def _perform_strct_analysis(self, method, kwargs, mapping=None):
         pass
 
 

--- a/aim2dat/strct/strct.py
+++ b/aim2dat/strct/strct.py
@@ -33,6 +33,7 @@ import aim2dat.utils.chem_formula as utils_cf
 import aim2dat.utils.print as utils_pr
 from aim2dat.utils.maths import calc_angle
 from aim2dat.utils.element_properties import get_atomic_number
+from aim2dat.utils.dict_tools import dict_retrieve_parameter
 
 
 def _compare_function_args(args1, args2):
@@ -56,19 +57,21 @@ def _create_index_dict(value):
     return index_dict
 
 
-def _check_calculated_properties(structure, func, func_args):
+def _check_calculated_properties(structure, func, func_args, mapping):
     property_name = "_".join(func.__name__.split("_")[1:])
+    output = None
     if structure.store_calculated_properties and property_name in structure._function_args:
         if _compare_function_args(structure._function_args[property_name], func_args):
-            return structure.extras[property_name]
-    calc_attr, calc_extra = func(structure, **func_args)
-    if calc_attr is not None:
-        structure.set_attribute(property_name, calc_attr)
+            output = structure.extras[property_name]
+    if output is None:
+        output = func(structure, **func_args)
+    if mapping is not None:
+        for key, attr_tree in mapping.items():
+            structure.set_attribute(key, dict_retrieve_parameter(output, attr_tree))
     if structure.store_calculated_properties:
-        if calc_extra is not None:
-            structure._extras[property_name] = calc_extra
+        structure._extras[property_name] = output
         structure._function_args[property_name] = func_args
-    return calc_extra
+    return output
 
 
 def _update_label_attributes_extras(strct_dict, label, attributes, site_attributes, extras):
@@ -273,6 +276,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
         self._element_dict = _create_index_dict(elements)
         self._chem_formula = utils_cf.transform_list_to_dict(elements)
         self._numbers = tuple(get_atomic_number(el) for el in elements)
+        self.reset_calculated_properties()
 
     @property
     def chem_formula(self) -> dict:
@@ -318,6 +322,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
                 "`cell` must be set if `pbc` is set to true for one or more direction."
             )
         self._pbc = value
+        self.reset_calculated_properties()
 
     @property
     def cell(self) -> Union[tuple, None]:
@@ -336,6 +341,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
                     for i1, i2 in [(1, 2), (0, 2), (0, 1)]
                 ]
             )
+            self.reset_calculated_properties()
             # if hasattr(self, "_positions"):
             #     self.set_positions(self.positions, is_cartesian=True)
 
@@ -369,6 +375,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
             raise ValueError("`kinds` must have the same length as `elements`.")
         self._kind_dict = _create_index_dict(value)
         self._kinds = tuple(value)
+        self.reset_calculated_properties()
 
     @property
     def site_attributes(self) -> Union[dict, None]:
@@ -398,6 +405,15 @@ class Structure(AnalysisMixin, ManipulationMixin):
         """Return attributes."""
         return copy.deepcopy(self._attributes)
 
+    @attributes.setter
+    def attributes(self, attributes: dict):
+        if attributes is None:
+            self._attributes = {}
+        elif isinstance(attributes, dict):
+            self._attributes = attributes
+        else:
+            raise TypeError("`attributes` must be a dictionary.")
+
     @property
     def extras(self) -> dict:
         """
@@ -417,6 +433,14 @@ class Structure(AnalysisMixin, ManipulationMixin):
         if not isinstance(value, bool):
             raise TypeError("`store_calculated_properties` needs to be of type bool.")
         self._store_calculated_properties = value
+
+    def reset_calculated_properties(self):
+        """
+        Reset all previously calculated properties that are stored within the
+        ``Structure`` object.
+        """
+        self._extras = {}
+        self._function_args = {}
 
     def iter_sites(
         self,
@@ -497,6 +521,7 @@ class Structure(AnalysisMixin, ManipulationMixin):
             _, cart_positions, scaled_positions = zip(*new_positions)
             self._positions = tuple(cart_positions)
             self._scaled_positions = tuple(scaled_positions)
+        self.reset_calculated_properties()
 
     def get_position(self, index: int, cartesian: bool = True, wrap: bool = False):
         """
@@ -895,8 +920,8 @@ class Structure(AnalysisMixin, ManipulationMixin):
             scaled_pos = tuple(float(p) for p in scaled_pos)
         return cart_pos, scaled_pos
 
-    def _perform_strct_analysis(self, method, kwargs):
-        return _check_calculated_properties(self, method, kwargs)
+    def _perform_strct_analysis(self, method, kwargs, mapping=None):
+        return _check_calculated_properties(self, method, kwargs, mapping)
 
     def perform_analysis(self, method: Callable, kwargs: dict = {}):
         """

--- a/aim2dat/strct/strct_comparison.py
+++ b/aim2dat/strct/strct_comparison.py
@@ -28,7 +28,7 @@ def _compare_structures_ffprint(
         return 1.0
     else:
         ffprints = [
-            strct.calculate_ffingerprint(
+            strct.calc_ffingerprint(
                 r_max=r_max,
                 delta_bin=delta_bin,
                 sigma=sigma,
@@ -123,7 +123,7 @@ def _compare_structures_direct_comp(
     el_lists = []
     positions = []
     for strct in [structure1, structure2]:
-        output = strct.determine_space_group(
+        output = strct.calc_space_group(
             symprec=symprec,
             angle_tolerance=angle_tolerance,
             hall_number=hall_number,
@@ -175,7 +175,7 @@ def _compare_structures_comp_sym(
     ):
         return False
     for strct in [structure1, structure2]:
-        sg_info = strct.determine_space_group(
+        sg_info = strct.calc_space_group(
             symprec=symprec,
             angle_tolerance=angle_tolerance,
             hall_number=hall_number,

--- a/aim2dat/strct/strct_coordination.py
+++ b/aim2dat/strct/strct_coordination.py
@@ -23,7 +23,7 @@ _supported_methods = [
 ]
 
 
-def calculate_coordination(
+def calc_coordination(
     structure,
     r_max: float,
     method: str,
@@ -70,7 +70,7 @@ def calculate_coordination(
         voronoi_weight_threshold,
     )
     if method == "voronoi":
-        voronoi_list = structure.calculate_voronoi_tessellation(r_max=r_max)
+        voronoi_list = structure.calc_voronoi_tessellation(r_max=r_max)
         method_args = [structure, voronoi_list] + method_args[method]
     else:
         elements_sc, kinds_sc, positions_sc, indices_sc, mapping, _ = _create_supercell_positions(
@@ -115,7 +115,7 @@ def calculate_coordination(
         is_optional.append(False)
     coordination = _calculate_statistical_quantities(structure, sites, stat_keys, is_optional)
     coordination["sites"] = sites
-    return None, coordination
+    return coordination
 
 
 def _coord_group_method_args(

--- a/aim2dat/strct/strct_misc.py
+++ b/aim2dat/strct/strct_misc.py
@@ -10,11 +10,11 @@ from typing import List
 import numpy as np
 
 # Internal library imports:
-from aim2dat.utils.maths import calc_angle
+import aim2dat.utils.maths as a2d_maths
 from aim2dat.strct.strct_super_cell import _create_supercell_positions
 
 
-def calculate_distance(
+def calc_distance(
     structure,
     site_index1,
     site_index2,
@@ -31,11 +31,10 @@ def calculate_distance(
             structure, site_index1, site_index2, backfold_positions
         )
 
-    output = (None, (distance, pos)) if return_pos else (None, distance)
-    return output
+    return (distance, pos) if return_pos else distance
 
 
-def calculate_angle(structure, site_index1, site_index2, site_index3, backfold_positions):
+def calc_angle(structure, site_index1, site_index2, site_index3, backfold_positions):
     """Calculate angle between three atomic positions."""
     comb_indices, is_int = _check_site_indices(structure, [site_index1, site_index2, site_index3])
     site_index1, site_index2, site_index3 = zip(*comb_indices)
@@ -46,14 +45,14 @@ def calculate_angle(structure, site_index1, site_index2, site_index3, backfold_p
     for idx1, idx2, idx3 in comb_indices:
         pos1 = np.array(structure["positions"][idx1])
         output.append(
-            calc_angle(positions[(idx1, idx2)] - pos1, positions[(idx1, idx3)] - pos1)
+            a2d_maths.calc_angle(positions[(idx1, idx2)] - pos1, positions[(idx1, idx3)] - pos1)
             * 180.0
             / np.pi
         )
-    return None, _parse_calc_output(comb_indices, output, is_int)
+    return _parse_calc_output(comb_indices, output, is_int)
 
 
-def calculate_dihedral_angle(
+def calc_dihedral_angle(
     structure, site_index1, site_index2, site_index3, site_index4, backfold_positions
 ):
     """Calculate dihedral angle between four atomic positions."""
@@ -77,8 +76,8 @@ def calculate_dihedral_angle(
             positions[(idx1, idx3)] - positions[(idx1, idx2)],
             positions[(idx1, idx4)] - positions[(idx1, idx3)],
         )
-        output.append(calc_angle(n_vector1, n_vector2) * 180.0 / np.pi)
-    return None, _parse_calc_output(comb_indices, output, is_int)
+        output.append(a2d_maths.calc_angle(n_vector1, n_vector2) * 180.0 / np.pi)
+    return _parse_calc_output(comb_indices, output, is_int)
 
 
 def _check_site_indices(structure, site_indices):

--- a/aim2dat/strct/strct_point_groups.py
+++ b/aim2dat/strct/strct_point_groups.py
@@ -159,7 +159,7 @@ def determine_point_group(structure, threshold_distance, threshold_angle, thresh
 
         # Derive point group from symmetry elements:
         point_group = _derive_point_group(symmetry_elements, threshold_angle)
-    return point_group, {"point_group": point_group, "symmetry_elements": symmetry_elements}
+    return {"point_group": point_group, "symmetry_elements": symmetry_elements}
 
 
 def _detect_sea(elements, positions, threshold_distance):

--- a/aim2dat/strct/strct_prdf.py
+++ b/aim2dat/strct/strct_prdf.py
@@ -13,9 +13,7 @@ from aim2dat.strct.strct_super_cell import _create_supercell_positions
 from aim2dat.fct.smearing import apply_smearing
 
 
-def calculate_ffingerprint(
-    structure, r_max, delta_bin, sigma, use_legacy_smearing, distinguish_kinds
-):
+def calc_ffingerprint(structure, r_max, delta_bin, sigma, use_legacy_smearing, distinguish_kinds):
     """Calculate f-fingerprint."""
     elements_uc = structure["elements"]
     element_dict = structure._element_dict
@@ -50,7 +48,7 @@ def calculate_ffingerprint(
             fingerprint -= 1.0
             atomic_fprint["fingerprints"][el_tuple] = fingerprint.tolist()
         atomic_fingerprints.append(atomic_fprint)
-    return None, (element_fingerprints, atomic_fingerprints)
+    return (element_fingerprints, atomic_fingerprints)
 
 
 def _calculate_prdf(structure, r_max, delta_bin, distinguish_kinds, method):

--- a/aim2dat/strct/strct_super_cell.py
+++ b/aim2dat/strct/strct_super_cell.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
     from aim2dat.strct.structure import Structure
 
 
-def calculate_voronoi_tessellation(
-    structure: Structure, r_max: float
-) -> Tuple[None, List[List[dict]]]:
+def calc_voronoi_tessellation(structure: Structure, r_max: float) -> Tuple[None, List[List[dict]]]:
     """Calculate voronoi tessellation."""
     voronoi_list = []
     (
@@ -55,7 +53,7 @@ def calculate_voronoi_tessellation(
                 key=lambda neighbor: (neighbor["index"], *neighbor["position"].tolist()),
             )
         )
-    return None, voronoi_list
+    return voronoi_list
 
 
 def _create_supercell_positions(

--- a/aim2dat/strct/structure_operations.py
+++ b/aim2dat/strct/structure_operations.py
@@ -253,9 +253,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
             )
         self._output_format = value
 
-    def calculate_stabilities(
-        self, unit: str = "eV", exclude_keys: list = []
-    ) -> Tuple[list, list]:
+    def calc_stabilities(self, unit: str = "eV", exclude_keys: list = []) -> Tuple[list, list]:
         """
         Calculate the formation energies and stabilities of all structures.
 
@@ -747,7 +745,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         threshold : float (optional)
             Threshold to consider two sites equivalent.
         cn_kwargs :
-            Optional keyword arguments passed on to the ``calculate_coordination`` function.
+            Optional keyword arguments passed on to the ``calc_coordination`` function.
 
         Returns
         -------
@@ -763,7 +761,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
             key2,
             site_index1,
             site_index2,
-            "calculate_coordination",
+            "calc_coordination",
             cn_kwargs,
             _coordination_compare_sites,
             compare_f_kwargs,
@@ -832,7 +830,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
             key2,
             site_index1,
             site_index2,
-            "calculate_ffingerprint",
+            "calc_ffingerprint",
             calc_f_kwargs,
             _ffingerprint_compare_sites,
             compare_f_kwargs,
@@ -859,7 +857,7 @@ class StructureOperations(AnalysisMixin, ManipulationMixin):
         threshold : float (optional)
             Threshold to consider two sites equivalent.
         cn_kwargs :
-            Optional keyword arguments passed on to the ``calculate_coordination`` function.
+            Optional keyword arguments passed on to the ``calc_coordination`` function.
 
         Returns
         --------

--- a/aim2dat/strct/surface.py
+++ b/aim2dat/strct/surface.py
@@ -63,7 +63,7 @@ class SurfaceGeneration:
         dict
             Dictionary containing the surface data.
         """
-        sg_details = self.structure.determine_space_group(
+        sg_details = self.structure.calc_space_group(
             symprec=symprec,
             angle_tolerance=angle_tolerance,
             hall_number=hall_number,

--- a/aim2dat/strct/surface_utils.py
+++ b/aim2dat/strct/surface_utils.py
@@ -336,7 +336,7 @@ def _transform_slab_to_primitive(slab, symprec, angle_tolerance, hall_number, ap
         slab = Structure(**slab)
 
     # Based on Litvin and Wike
-    _, spglib_output = _space_group_analysis(
+    spglib_output = _space_group_analysis(
         slab,
         symprec,
         angle_tolerance,

--- a/tests/strct/test_analysis.py
+++ b/tests/strct/test_analysis.py
@@ -15,20 +15,20 @@ MISC_PATH = os.path.dirname(__file__) + "/miscellaneous/"
 COORDINATION_PATH = os.path.dirname(__file__) + "/coordination/"
 
 
-def test_calculate_distance_angle_dihedral_errors():
+def test_calc_distance_angle_dihedral_errors():
     """Test correct error handling on site indices input."""
     strct = Structure.from_file(STRUCTURES_PATH + "Benzene.xyz")
     with pytest.raises(ValueError) as error:
-        strct.calculate_distance([1] * 3, [0, 2, 20])
+        strct.calc_distance([1] * 3, [0, 2, 20])
     assert str(error.value) == "`site_index` needs to be smaller than the number of sites."
     with pytest.raises(TypeError) as error:
-        strct.calculate_distance([1.0] * 3, [0, 2, 3])
+        strct.calc_distance([1.0] * 3, [0, 2, 3])
     assert str(error.value) == "`site_index` must be of type int, list, tuple, np.ndarray or None."
     with pytest.raises(TypeError) as error:
-        strct.calculate_distance([0, 2.0, 3], [1] * 3)
+        strct.calc_distance([0, 2.0, 3], [1] * 3)
     assert str(error.value) == "`site_index` must be of type int, list, tuple, np.ndarray or None."
     with pytest.raises(TypeError) as error:
-        strct.calculate_distance([1], "test")
+        strct.calc_distance([1], "test")
     assert str(error.value) == "`site_index` must be of type int, list, tuple, np.ndarray or None."
 
 
@@ -36,11 +36,11 @@ def test_calculate_distance_angle_dihedral_errors():
     "structure, file_suffix",
     [("Benzene", "xyz"), ("ZIF-8", "cif"), ("MOF-303_3xH2O_flawed", "xsf")],
 )
-def test_calculate_distance(structure, file_suffix):
-    """Test calculate_distance function."""
+def test_calc_distance(structure, file_suffix):
+    """Test calc_distance function."""
     ref_outputs = load_yaml_file(MISC_PATH + structure + "_ref.yaml")
     strct = Structure.from_file(STRUCTURES_PATH + structure + "." + file_suffix)
-    dist = strct.calculate_distance(**ref_outputs["distance"]["function_args"])
+    dist = strct.calc_distance(**ref_outputs["distance"]["function_args"])
     if isinstance(ref_outputs["distance"]["reference"], list):
         assert [
             abs(dist[(idx0, idx1)] - val) < 1e-5
@@ -55,8 +55,8 @@ def test_calculate_distance(structure, file_suffix):
 
 
 @pytest.mark.parametrize("structure, file_suffix", [("ZIF-8", "cif"), ("ScBDC", "cif")])
-def test_calculate_distance_sc(structure, file_suffix):
-    """Test calculate_distance function using the super cell."""
+def test_calc_distance_sc(structure, file_suffix):
+    """Test calc_distance function using the super cell."""
     ref_outputs = load_yaml_file(MISC_PATH + structure + "_ref.yaml")
     strct = Structure.from_file(
         STRUCTURES_PATH + structure + "." + file_suffix,
@@ -65,7 +65,7 @@ def test_calculate_distance_sc(structure, file_suffix):
     )
     if isinstance(strct, list):
         strct = strct[0]
-    dist = strct.calculate_distance(**ref_outputs["distance_sc"]["function_args"])
+    dist = strct.calc_distance(**ref_outputs["distance_sc"]["function_args"])
     if ref_outputs["distance_sc"]["reference"] is None:
         assert dist is None
     else:
@@ -95,11 +95,11 @@ def test_calculate_distance_sc(structure, file_suffix):
 
 
 @pytest.mark.parametrize("structure, file_suffix", [("Benzene", "xyz"), ("ZIF-8", "cif")])
-def test_calculate_angle(structure, file_suffix):
-    """Test calculate_angle function."""
+def test_calc_angle(structure, file_suffix):
+    """Test calc_angle function."""
     ref_outputs = load_yaml_file(MISC_PATH + structure + "_ref.yaml")
     strct = Structure.from_file(STRUCTURES_PATH + structure + "." + file_suffix)
-    angles = strct.calculate_angle(**ref_outputs["angle"]["function_args"])
+    angles = strct.calc_angle(**ref_outputs["angle"]["function_args"])
     if isinstance(ref_outputs["angle"]["reference"], list):
         for angle, ref in zip(angles.values(), ref_outputs["angle"]["reference"]):
             assert abs(angle - ref) < 1e-3, "Wrong angle."
@@ -108,15 +108,15 @@ def test_calculate_angle(structure, file_suffix):
 
 
 @pytest.mark.parametrize("structure, file_suffix", [("ScBDC", "cif")])
-def test_calculate_dihedral_angle(structure, file_suffix):
-    """Test calculate_dihedral_angle function."""
+def test_calc_dihedral_angle(structure, file_suffix):
+    """Test calc_dihedral_angle function."""
     ref_outputs = load_yaml_file(MISC_PATH + structure + "_ref.yaml")
     strct = Structure.from_file(
         STRUCTURES_PATH + structure + "." + file_suffix,
         backend="internal",
         backend_kwargs={"strct_check_chem_formula": False},
     )[0]
-    angles = strct.calculate_dihedral_angle(**ref_outputs["dihedral_angle"]["function_args"])
+    angles = strct.calc_dihedral_angle(**ref_outputs["dihedral_angle"]["function_args"])
     assert len(angles) == len(ref_outputs["dihedral_angle"]["reference"])
     for angle, ref in zip(angles.values(), ref_outputs["dihedral_angle"]["reference"]):
         assert abs(angle - ref) < 1e-3, "Wrong angle."
@@ -126,14 +126,14 @@ def test_cn_analysis_error():
     """Test method validation of coordination analysis."""
     strct = Structure(**dict(load_yaml_file(STRUCTURES_PATH + "GaAs_216_conv.yaml")))
     with pytest.raises(ValueError) as error:
-        strct.calculate_coordination(method="test")
+        strct.calc_coordination(method="test")
     assert (
         str(error.value)
         == "Method 'test' is not supported. Supported methods are: 'minimum_distance', "
         "'n_nearest_neighbours', 'atomic_radius', 'econ', 'voronoi'."
     )
     with pytest.raises(ValueError) as error:
-        strct.calculate_coordination(method="voronoi", voronoi_weight_type="test")
+        strct.calc_coordination(method="voronoi", voronoi_weight_type="test")
     assert str(error.value) == "`weight_type` 'test' is not supported."
 
 
@@ -162,7 +162,7 @@ def test_cn_analysis(nested_dict_comparison, structure_label, method):
     inputs = dict(load_yaml_file(STRUCTURES_PATH + structure_label + ".yaml"))
     ref = dict(load_yaml_file(COORDINATION_PATH + structure_label + "_" + method + ".yaml"))
     structure = Structure(**inputs)
-    output = structure.calculate_coordination(**ref["parameters"])
+    output = structure.calc_coordination(**ref["parameters"])
     sites = output.pop("sites")
     sites_ref = ref["ref"].pop("sites")
     assert len(sites) == len(sites_ref)

--- a/tests/strct/test_ext_analysis.py
+++ b/tests/strct/test_ext_analysis.py
@@ -8,7 +8,7 @@ import pytest
 
 # Internal library imports
 from aim2dat.strct import Structure
-from aim2dat.strct.ext_analysis import determine_molecular_fragments, create_graph
+from aim2dat.strct.ext_analysis import calc_molecular_fragments, calc_graph
 from aim2dat.io.yaml import load_yaml_file
 
 STRUCTURES_PATH = os.path.dirname(__file__) + "/structures/"
@@ -18,7 +18,7 @@ FRAG_PATH = os.path.dirname(__file__) + "/fragment_analysis/"
 def test_func_args_extraction():
     """Test correct extraction of function arguments done by the decorator."""
     strct = Structure(**load_yaml_file(STRUCTURES_PATH + "GaAs_216_prim.yaml"))
-    create_graph(strct, method="n_nearest_neighbours")
+    calc_graph(strct, method="n_nearest_neighbours")
     assert strct._function_args == {
         "coordination": {
             "r_max": 10.0,
@@ -40,7 +40,7 @@ def test_func_args_extraction():
             "graphviz_edge_rank_colors": ["blue", "red", "green", "orange", "darkblue"],
         },
     }
-    create_graph(strct)
+    calc_graph(strct)
     assert strct._function_args == {
         "coordination": {
             "r_max": 10.0,
@@ -70,13 +70,11 @@ def test_func_args_extraction():
         ("ZIF-8", ".cif", "internal"),
     ],
 )
-def test_determine_molecular_fragments_function(
-    structure_comparison, system, file_suffix, backend
-):
-    """Test determine_molecular_fragments function."""
+def test_calc_molecular_fragments_function(structure_comparison, system, file_suffix, backend):
+    """Test calc_molecular_fragments function."""
     kwargs, ref = load_yaml_file(FRAG_PATH + system + ".yaml")
     strct = Structure.from_file(STRUCTURES_PATH + system + file_suffix, backend=backend)
-    fragments = determine_molecular_fragments(strct, **kwargs)
+    fragments = calc_molecular_fragments(strct, **kwargs)
     for frag, frag_ref in zip(fragments, ref):
         structure_comparison(frag, Structure(**frag_ref))
         assert frag.site_attributes["parent_indices"] == tuple(
@@ -84,10 +82,10 @@ def test_determine_molecular_fragments_function(
         )
 
 
-def test_determine_graph(nested_dict_comparison):
+def test_calc_graph(nested_dict_comparison):
     """Test creating a graph from a structure."""
     strct = Structure(**load_yaml_file(STRUCTURES_PATH + "GaAs_216_prim.yaml"))
-    nx_graph, graphviz_graph = create_graph(
+    nx_graph, graphviz_graph = calc_graph(
         strct, get_graphviz_graph=True, method="minimum_distance"
     )
     assert list(nx_graph.edges) == [

--- a/tests/strct/test_structure.py
+++ b/tests/strct/test_structure.py
@@ -229,14 +229,14 @@ def test_list_methods():
         "to_aiida_structuredata",
     ]
     assert Structure.analysis_methods == [
-        "determine_point_group",
-        "determine_space_group",
-        "calculate_distance",
-        "calculate_angle",
-        "calculate_dihedral_angle",
-        "calculate_voronoi_tessellation",
-        "calculate_coordination",
-        "calculate_ffingerprint",
+        "calc_point_group",
+        "calc_space_group",
+        "calc_distance",
+        "calc_angle",
+        "calc_dihedral_angle",
+        "calc_voronoi_tessellation",
+        "calc_coordination",
+        "calc_ffingerprint",
     ]
     assert Structure.manipulation_methods == [
         "delete_atoms",

--- a/tests/strct/test_structure_c.py
+++ b/tests/strct/test_structure_c.py
@@ -149,7 +149,7 @@ def test_create_pandas_df(nested_dict_comparison):
     for strct in structures:
         strct_collect.append(strct, **dict(load_yaml_file(STRUCTURES_PATH + strct + ".yaml")))
     strct_ops = StructureOperations(strct_collect)
-    strct_ops[strct_collect.labels].calculate_coordination(**coord_kwargs)
+    strct_ops[strct_collect.labels].calc_coordination(**coord_kwargs)
     df = strct_collect.create_pandas_df()
     df_dict = {}
     for column in df.columns:
@@ -369,14 +369,14 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
         "okeeffe_weight_threshold": 0.5,
     }
     strct_ops = StructureOperations(strct_c)
-    coord = strct_ops[0].calculate_coordination(**function_args)
+    coord = strct_ops[0].calc_coordination(**function_args)
     assert (
         strct_ops.structures._structures[0]._function_args["coordination"] == function_args
     ), "Function parameters are wrong."
     assert (
         strct_ops.structures._structures[0]["extras"]["coordination"] == coord
     ), "Calculated extra is wrong."
-    assert strct_ops[0].calculate_coordination(**function_args) == coord, "Recalculation is wrong."
+    assert strct_ops[0].calc_coordination(**function_args) == coord, "Recalculation is wrong."
 
     function_args = {
         "symprec": 0.005,
@@ -387,7 +387,7 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
         "return_primitive_structure": False,
         "return_standardized_structure": False,
     }
-    space_group = strct_ops[0].determine_space_group(**function_args)
+    space_group = strct_ops[0].calc_space_group(**function_args)
     assert (
         strct_ops.structures._structures[0]._function_args["space_group"] == function_args
     ), "Function parameters are wrong."
@@ -398,11 +398,9 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
     assert (
         strct_ops.structures._structures[0]["extras"]["space_group"] == space_group
     ), "Calculated extra is wrong."
-    assert (
-        strct_ops[0].determine_space_group(**function_args) == space_group
-    ), "Recalculation is wrong."
+    assert strct_ops[0].calc_space_group(**function_args) == space_group, "Recalculation is wrong."
     function_args["return_sym_operations"] = False
-    space_group = strct_ops[0].determine_space_group(**function_args)
+    space_group = strct_ops[0].calc_space_group(**function_args)
     assert (
         strct_ops.structures._structures[0]._function_args["space_group"] == function_args
     ), "Function parameters are wrong."
@@ -423,7 +421,7 @@ def test_store_calc_properties(create_structure_collection_object, nested_dict_c
     assert not strct_ops.structures._structures[
         1
     ].store_calculated_properties, "Setting `store_calculated_properties` to False not working."
-    space_group = strct_ops[1].determine_space_group(**function_args)
+    space_group = strct_ops[1].calc_space_group(**function_args)
     assert (
         strct_ops.structures._structures[1]._function_args == {}
     ), "Function parameters are wrong."

--- a/tests/strct/test_structure_op.py
+++ b/tests/strct/test_structure_op.py
@@ -31,11 +31,11 @@ def test_structure_op_basics():
     with pytest.raises(TypeError) as error:
         StructureOperations([1, 2, 3])
 
-    assert isinstance(strct_ops["Cs2Te_62_prim"].calculate_distance(0, 1), float)
-    assert isinstance(strct_ops[["Cs2Te_62_prim", "NaCl_225_prim"]].calculate_distance(0, 1), dict)
+    assert isinstance(strct_ops["Cs2Te_62_prim"].calc_distance(0, 1), float)
+    assert isinstance(strct_ops[["Cs2Te_62_prim", "NaCl_225_prim"]].calc_distance(0, 1), dict)
     strct_ops.output_format = "DataFrame"
     assert isinstance(
-        strct_ops[["Cs2Te_62_prim", "NaCl_225_prim"]].calculate_distance(0, 1), pd.DataFrame
+        strct_ops[["Cs2Te_62_prim", "NaCl_225_prim"]].calc_distance(0, 1), pd.DataFrame
     )
     with pytest.raises(TypeError) as error:
         strct_ops.output_format = 10

--- a/tests/strct/test_structure_op_calc_functions.py
+++ b/tests/strct/test_structure_op_calc_functions.py
@@ -9,10 +9,10 @@ import pytest
 # Internal library imports:
 from aim2dat.strct import StructureCollection, StructureOperations
 from aim2dat.strct.ext_analysis import (
-    calculate_prdf,
-    calculate_ffingerprint_order_p,
-    calculate_warren_cowley_order_p,
-    calculate_planes,
+    calc_prdf,
+    calc_ffingerprint_order_p,
+    calc_warren_cowley_order_p,
+    calc_planes,
 )
 from aim2dat.io.yaml import load_yaml_file
 
@@ -57,17 +57,19 @@ def test_ffingerprint_order_parameters(structure, ref_order_p):
     # inputs["structure_label"] = structure
     strct_collect.append(structure, **inputs)
     strct_ops = StructureOperations(strct_collect)
-    t_order_p, site_order_p = strct_ops[structure].perform_analysis(
-        method=calculate_ffingerprint_order_p,
+    output = strct_ops[structure].perform_analysis(
+        method=calc_ffingerprint_order_p,
         kwargs={"r_max": 20.0, "delta_bin": 0.005, "sigma": 10.0},
     )
     assert (
-        abs(t_order_p - ref_order_p[0]) < 1e-3
+        abs(output["order_p"] - ref_order_p[0]) < 1e-3
     ), f"Total order parameter of structure {structure} is wrong."
-    assert len(site_order_p) == len(
+    assert len(output["site_order_p"]) == len(
         ref_order_p[1]
     ), f"Wrong number of site order parameters for structure {structure}."
-    for idx, (site_order_p0, ref_site_order_p0) in enumerate(zip(site_order_p, ref_order_p[1])):
+    for idx, (site_order_p0, ref_site_order_p0) in enumerate(
+        zip(output["site_order_p"], ref_order_p[1])
+    ):
         assert (
             abs(site_order_p0 - ref_site_order_p0) < 1e-3
         ), f"Order parameter of site {idx} of structure {structure} is wrong."
@@ -82,7 +84,7 @@ def test_prdf_functions(structure, nested_dict_comparison):
     strct_c.append(structure, **inputs)
     strct_ops = StructureOperations(strct_c)
     element_prdf, atomic_prdf = strct_ops[0].perform_analysis(
-        method=calculate_prdf, kwargs=ref["parameters"]
+        method=calc_prdf, kwargs=ref["parameters"]
     )
 
     assert len(element_prdf) == len(ref["element_prdf"]), "Wrong number of el-pairs."
@@ -130,7 +132,7 @@ def test_warren_cowley_like_order_parameters(nested_dict_comparison, structure, 
     strct_c.append(structure, **inputs)
     strct_ops = StructureOperations(strct_c)
     output = strct_ops[0].perform_analysis(
-        method=calculate_warren_cowley_order_p,
+        method=calc_warren_cowley_order_p,
         kwargs={"r_max": r_max, "max_shells": max_shells},
     )
     nested_dict_comparison(output, ref)
@@ -147,9 +149,7 @@ def test_planes(structure, file_type):
     strct_collect = StructureCollection()
     strct_collect.append_from_file("structure", STRUCTURES_PATH + structure + "." + file_type)
     strct_ops = StructureOperations(strct_collect)
-    planes = strct_ops["structure"].perform_analysis(
-        method=calculate_planes, kwargs=ref["parameters"]
-    )
+    planes = strct_ops["structure"].perform_analysis(method=calc_planes, kwargs=ref["parameters"])
 
     for plane, ref_plane in zip(planes, ref["reference"]):
         assert len(plane["site_indices"]) == len(
@@ -177,7 +177,7 @@ def test_stabilities(create_structure_collection_object):
     for idx0, strct in enumerate(ref["input"]):
         strct_c.append("test_" + str(idx0), **strct)
     strct_ops = StructureOperations(strct_c)
-    f_e, st = strct_ops.calculate_stabilities(unit="eV")
+    f_e, st = strct_ops.calc_stabilities(unit="eV")
     f_e = f_e[1:]
     st = st[1:]
     assert all(

--- a/tests/strct/test_structure_op_determine_functions.py
+++ b/tests/strct/test_structure_op_determine_functions.py
@@ -23,8 +23,8 @@ POINT_GROUP_PATH = os.path.dirname(__file__) + "/point_group_analysis/"
         ("Cs2Te_62_prim", "yaml", {"symprec": 0.01, "return_sym_operations": True}),
     ],
 )
-def test_determine_space_group(nested_dict_comparison, structure, file_suffix, kwargs):
-    """Test determine_space_group function."""
+def test_calc_space_group(nested_dict_comparison, structure, file_suffix, kwargs):
+    """Test calc_space_group function."""
     ref_outputs = dict(load_yaml_file(SPACE_GROUP_PATH + structure + "_ref.yaml"))
     strct_c = StructureCollection()
     if file_suffix == "yaml":
@@ -34,7 +34,7 @@ def test_determine_space_group(nested_dict_comparison, structure, file_suffix, k
             "test", STRUCTURES_PATH + structure + "." + file_suffix, backend="internal"
         )
     strct_ops = StructureOperations(strct_c)
-    sg_dict = strct_ops["test"].determine_space_group(**kwargs)
+    sg_dict = strct_ops["test"].calc_space_group(**kwargs)
     nested_dict_comparison(sg_dict, ref_outputs)
     assert strct_c["test"]["attributes"]["space_group"] == sg_dict["space_group"]["number"]
 
@@ -73,5 +73,5 @@ def test_point_group_determination(nested_dict_comparison, structure):
     strct_c = StructureCollection()
     strct_c.append(structure, **inputs)
     strct_ops = StructureOperations(strct_c)
-    nested_dict_comparison(strct_ops[structure].determine_point_group(), ref)
+    nested_dict_comparison(strct_ops[structure].calc_point_group(), ref)
     assert strct_c[structure]["attributes"]["point_group"] == pg


### PR DESCRIPTION
This PR introduces new names for all analysis methods and implements a "mapping" dictionary which will always update the ``Structure.attributes`` dictionary (regardless whether the properties are calculated anew or not).

The calculated properties are now erased if the underlying ``Structure`` object is changed.

Closes #121 