### PR TITLE
Change resolve atoms to LDOS list and add option for lods as list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Version 0.4.0
 * A workflow was added to calculate the adsorption energies [``cp2k-adsorption-mofs-*``, ``cp2k-preadsorption-mofs-*``, ``cp2k-molecule-*``] (`PR #153 <https://github.com/aim2dat/aim2dat/pull/153>`_).
 * Hybrid functionals *PBE0* and *HSE06* with the *ADMM method* were implemented. As well as *rVV10* and *D3* dispersion corrections for *R2SCAN* and the hybrid functionals (`PR #153 <https://github.com/aim2dat/aim2dat/pull/153>`_).
 * ``aiida_workflows.cp2k.base_opt_work_chain._BaseOptimizationWorkChain`` contains now the option to fix atoms ``optimization_p.fixed_atoms`` and also to ignore scf convergence failure ``ignore_convergence_failure`` (`PR #153 <https://github.com/aim2dat/aim2dat/pull/153>`_).
+* ``aiida_workflows.cp2k.pdos_work_chain.PDOSWorkChain`` contains now the option to print the local PDOS, projected on subsets of atoms given through lists ``ldos`` (`PR #158 <https://github.com/aim2dat/aim2dat/pull/158>`_).
 
 **Fixes:**
 
@@ -37,6 +38,7 @@ Version 0.4.0
 * The `BASIS_SET_FILE_NAME` and `POTENTIAL_FILE_NAME` was changed from `[BASIS_MOLOPT, BASIS_MOLOPT_UCL]` to `BASIS_MOLOPT_UZH` and from `GTH_POTENTIALS` to `POTENTIAL_UZH` for CP2K workflows. Additionally, the `PBE` functional includes `GGA` in its `BASIS_SET` and `POTENTIAL` for each `KIND`. `SCAN` thus includes `MGGA` instead of `SCAN`. Shortrange `SR` for most metals become redundant by introducing `BASIS_MOLOPT_UZH` (`PR #153 <https://github.com/aim2dat/aim2dat/pull/153>`_).
 * The bond distance from the hydrogen molecule was reduced from `0.909862` to `0.74` (`PR #153 <https://github.com/aim2dat/aim2dat/pull/153>`_).
 * The Materials Project openAPI interface does not support ICSD IDs anymore, instead the new key `theoretical` is added (`PR #154 <https://github.com/aim2dat/aim2dat/pull/154>`_).
+* ``aiida_workflows.cp2k.pdos_work_chain.PDOSWorkChain.resolve_atoms`` resolves the atoms now via local PDOS instead of changing each atom in a separate kind (`PR #158 <https://github.com/aim2dat/aim2dat/pull/158>`_).
 
 
 Version 0.3.0

--- a/aim2dat/aiida_workflows/cp2k/pdos_work_chain.py
+++ b/aim2dat/aiida_workflows/cp2k/pdos_work_chain.py
@@ -57,7 +57,7 @@ class PDOSWorkChain(_BaseCoreWorkChain):
             "ldos",
             valid_type=aiida_orm.List,
             required=False,
-            help=" Print the local PDOS, projected on subsets of atoms given through lists.",
+            help="Print the local PDOS, projected on subsets of atoms given through lists.",
         )
         spec.input(
             "wfn_n_homo",

--- a/aim2dat/aiida_workflows/protocols/cp2k-adsorption-mofs-hybrid_v1.1.yaml
+++ b/aim2dat/aiida_workflows/protocols/cp2k-adsorption-mofs-hybrid_v1.1.yaml
@@ -1,0 +1,285 @@
+%YAML 1.2
+---
+# Protocol with hybrid settings for the adsorption workflow.
+title: cp2k-adsorption-hybrid
+version: '1.0'
+description: Hybrid settings to calculated the adsorption properties.
+dependencies:
+- [aiida-core, '1.6', Null]
+parent_node_type: core.structure
+parent_node_input:
+  find_scf_parameters: structural_p.structure
+  pre_geo_opt: structural_p.structure
+tasks:
+  find_scf_parameters:
+    process: aim2dat.cp2k.find_scf_p
+    blacklist_inputs:
+    - custom_scf_method
+  pre_geo_opt:
+    process: aim2dat.cp2k.geo_opt
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      find_scf_parameters:
+      - [scf_parameters, structural_p.scf_parameters]
+  geo_opt:
+    process: aim2dat.cp2k.geo_opt
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      find_scf_parameters:
+      - [scf_parameters, structural_p.scf_parameters]
+      pre_geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+  pdos:
+    process: aim2dat.cp2k.pdos
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+  partial_charges:
+    process: aim2dat.cp2k.partial_charges
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+      - [cp2k.remote_folder, cp2k.parent_calc_folder]
+      - [scf_parameters, structural_p.scf_parameters]
+general_input:
+  cp2k.parameters:
+    value:
+      GLOBAL:
+        PRINT_LEVEL: MEDIUM
+        PREFERRED_DIAG_LIBRARY: SCALAPACK
+        EXTENDED_FFT_LENGTHS: true
+      FORCE_EVAL:
+        METHOD: Quickstep
+        STRESS_TENSOR: ANALYTICAL
+        DFT:
+          MGRID: {}
+          POISSON: {PERIODIC: XYZ, POISSON_SOLVER: PERIODIC}
+          BASIS_SET_FILE_NAME: [BASIS_MOLOPT_UZH, BASIS_ADMM_UZH]
+          POTENTIAL_FILE_NAME: POTENTIALS_UZH
+          QS: {EXTRAPOLATION: USE_GUESS, EPS_DEFAULT: 1e-14, METHOD: GPW, MIN_PAIR_LIST_RADIUS: -1}
+          SCF: {EPS_SCF: 5.0e-7}
+          XC: {}
+        SUBSYS:
+          CELL: {PERIODIC: XYZ}
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  enable_roks:
+    value: false
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  scf_method:
+    value: orbital_transformation
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, partial_charges]
+  adjust_scf_parameters:
+    value: true
+    aiida_node: true
+    tasks: [pre_geo_opt, geo_opt, pdos, partial_charges]
+  max_iterations:
+    value: 100
+    aiida_node: true
+    compare: False
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  optimization_p.max_force->pre_geo_opt:
+    value: 0.0005
+    aiida_node: true
+  optimization_p.max_force->geo_opt:
+    value: 0.00001
+    aiida_node: true
+  scf_method->pdos:
+    value: super_cell
+    aiida_node: true
+  minimum_cell_length->pdos:
+    value: 25.0
+    aiida_node: true
+  maximum_cell_length->pdos:
+    value: 40.0
+    aiida_node: true
+  critic2.parameters->partial_charges:
+    value:
+    - crystal aiida-ELECTRON_DENSITY-1_0.cube
+    - load aiida-ELECTRON_DENSITY-1_0.cube zpsp
+    - load aiida-ELECTRON_DENSITY-1_0.cube
+    - integrable 2
+    - yt
+    dependency: critic2.code
+    aiida_node: true
+  chargemol.parameters->partial_charges:
+    value: {periodicity along A, B, and C vectors: [true, true, true], charge type: DDEC6}
+    dependency: chargemol.code
+    aiida_node: true
+user_input:
+  scf_extended_system:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.xc_functional:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.cutoff_values:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.basis_sets:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.pseudo_file:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.basis_file:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.cutoff_values->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  numerical_p.basis_sets->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  numerical_p.pseudo_file->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+  numerical_p.basis_file->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+  numerical_p.cutoff_radius:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.max_memory:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  ignore_convergence_failure:
+    validation: aim2dat.cp2k.geo_opt
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [pre_geo_opt]
+  optimization_p.fixed_atoms:
+    validation: aim2dat.cp2k.geo_opt
+    aiida_node: true
+    compare: false
+    tasks: [pre_geo_opt, geo_opt]
+  resolve_atoms->pdos:
+    validation: aim2dat.cp2k.pdos
+    aiida_node: true
+    optional: true
+    compare: false
+  ldos->pdos:
+    validation: aim2dat.cp2k.pdos
+    aiida_node: true
+    optional: true
+    compare: false
+  cp2k.code:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  cp2k.metadata:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  critic2.code:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  critic2.metadata:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  chargemol.code:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    optional: true
+    tasks: [partial_charges]
+  chargemol.metadata:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  chargemol.path_atomic_densities:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    dependency: chargemol.code
+    compare: false
+    tasks: [partial_charges]
+  clean_workdir:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+results:
+  scf_method_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [method_level]
+  scf_parameter_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [parameter_level]
+  scf_smearing_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [smearing_level]
+  optimized_structure:
+    task: geo_opt
+    output_port: cp2k.output_structure
+  total_energy:
+    task: geo_opt
+    output_port: cp2k.output_parameters
+    retrieve_value: [energy]
+    unit: Hartree
+  pdos:
+    task: pdos
+    output_port: cp2k.output_pdos
+  bader_populations:
+    task: partial_charges
+    output_port: critic2.output_bader_populations
+  ddec6_populations:
+    task: partial_charges
+    output_port: chargemol.output_ddec6_populations
+  hirshfeld_populations:
+    task: partial_charges
+    output_port: cp2k.output_hirshfeld_populations
+  mulliken_populations:
+    task: partial_charges
+    output_port: cp2k.output_mulliken_populations

--- a/aim2dat/aiida_workflows/protocols/cp2k-adsorption-mofs-standard_v1.1.yaml
+++ b/aim2dat/aiida_workflows/protocols/cp2k-adsorption-mofs-standard_v1.1.yaml
@@ -1,0 +1,288 @@
+%YAML 1.2
+---
+# Protocol with standard settings for the adsorption workflow.
+title: cp2k-adsorption-standard
+version: '1.0'
+description: Standard settings to calculated the adsorption properties.
+dependencies:
+- [aiida-core, '1.6', Null]
+parent_node_type: core.structure
+parent_node_input:
+  find_scf_parameters: structural_p.structure
+  pre_geo_opt: structural_p.structure
+tasks:
+  find_scf_parameters:
+    process: aim2dat.cp2k.find_scf_p
+    blacklist_inputs:
+    - custom_scf_method
+  pre_geo_opt:
+    process: aim2dat.cp2k.geo_opt
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      find_scf_parameters:
+      - [scf_parameters, structural_p.scf_parameters]
+  geo_opt:
+    process: aim2dat.cp2k.geo_opt
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      find_scf_parameters:
+      - [scf_parameters, structural_p.scf_parameters]
+      pre_geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+  pdos:
+    process: aim2dat.cp2k.pdos
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+      - [scf_parameters, structural_p.scf_parameters]
+  partial_charges:
+    process: aim2dat.cp2k.partial_charges
+    blacklist_inputs:
+    - custom_scf_method
+    dependencies:
+      geo_opt:
+      - [cp2k.output_structure, structural_p.structure]
+      - [cp2k.remote_folder, cp2k.parent_calc_folder]
+      - [scf_parameters, structural_p.scf_parameters]
+general_input:
+  cp2k.parameters:
+    value:
+      GLOBAL:
+        PRINT_LEVEL: MEDIUM
+        PREFERRED_DIAG_LIBRARY: SCALAPACK
+        EXTENDED_FFT_LENGTHS: true
+      FORCE_EVAL:
+        METHOD: Quickstep
+        STRESS_TENSOR: ANALYTICAL
+        DFT:
+          MGRID: {}
+          POISSON: {PERIODIC: XYZ, POISSON_SOLVER: PERIODIC}
+          BASIS_SET_FILE_NAME: BASIS_MOLOPT_UZH
+          POTENTIAL_FILE_NAME: POTENTIALS_UZH
+          QS: {EXTRAPOLATION: USE_GUESS, EPS_DEFAULT: 1e-14}
+          SCF: {EPS_SCF: 5.0e-7}
+          KPOINTS:
+            EPS_GEO: 1.0E-8
+          XC: {}
+        SUBSYS:
+          CELL: {PERIODIC: XYZ}
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.kpoints_ref_dist:
+    value: 0.15
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, partial_charges]
+  enable_roks:
+    value: false
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  scf_method:
+    value: density_mixing
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, partial_charges]
+  adjust_scf_parameters:
+    value: true
+    aiida_node: true
+    tasks: [pre_geo_opt, geo_opt, pdos, partial_charges]
+  always_add_unocc_states:
+    value: true
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, partial_charges]
+  factor_unocc_states:
+    value: 0.75
+    aiida_node: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  max_iterations:
+    value: 100
+    aiida_node: true
+    compare: False
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  optimization_p.max_force->pre_geo_opt:
+    value: 0.0005
+    aiida_node: true
+  optimization_p.max_force->geo_opt:
+    value: 0.00001
+    aiida_node: true
+  scf_method->pdos:
+    value: super_cell
+    aiida_node: true
+  minimum_cell_length->pdos:
+    value: 25.0
+    aiida_node: true
+  maximum_cell_length->pdos:
+    value: 40.0
+    aiida_node: true
+  critic2.parameters->partial_charges:
+    value:
+    - crystal aiida-ELECTRON_DENSITY-1_0.cube
+    - load aiida-ELECTRON_DENSITY-1_0.cube zpsp
+    - load aiida-ELECTRON_DENSITY-1_0.cube
+    - integrable 2
+    - yt
+    dependency: critic2.code
+    aiida_node: true
+  chargemol.parameters->partial_charges:
+    value: {periodicity along A, B, and C vectors: [true, true, true], charge type: DDEC6}
+    dependency: chargemol.code
+    aiida_node: true
+user_input:
+  scf_extended_system:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.xc_functional:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  numerical_p.cutoff_values:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.basis_sets:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.pseudo_file:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.basis_file:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, geo_opt, pdos, partial_charges]
+  numerical_p.cutoff_values->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  numerical_p.basis_sets->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  numerical_p.pseudo_file->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+  numerical_p.basis_file->pre_geo_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+  ignore_convergence_failure:
+    validation: aim2dat.cp2k.geo_opt
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [pre_geo_opt]
+  optimization_p.fixed_atoms:
+    validation: aim2dat.cp2k.geo_opt
+    aiida_node: true
+    compare: false
+    tasks: [pre_geo_opt, geo_opt]
+  resolve_atoms->pdos:
+    validation: aim2dat.cp2k.pdos
+    aiida_node: true
+    optional: true
+    compare: false
+  ldos->pdos:
+    validation: aim2dat.cp2k.pdos
+    aiida_node: true
+    optional: true
+    compare: false
+  cp2k.code:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  cp2k.metadata:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+  critic2.code:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  critic2.metadata:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  chargemol.code:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    optional: true
+    tasks: [partial_charges]
+  chargemol.metadata:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [partial_charges]
+  chargemol.path_atomic_densities:
+    validation: aim2dat.cp2k.partial_charges
+    aiida_node: true
+    dependency: chargemol.code
+    compare: false
+    tasks: [partial_charges]
+  clean_workdir:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, pre_geo_opt, geo_opt, pdos, partial_charges]
+results:
+  scf_method_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [method_level]
+  scf_parameter_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [parameter_level]
+  scf_smearing_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [smearing_level]
+  optimized_structure:
+    task: geo_opt
+    output_port: cp2k.output_structure
+  total_energy:
+    task: geo_opt
+    output_port: cp2k.output_parameters
+    retrieve_value: [energy]
+    unit: Hartree
+  pdos:
+    task: pdos
+    output_port: cp2k.output_pdos
+  bader_populations:
+    task: partial_charges
+    output_port: critic2.output_bader_populations
+  ddec6_populations:
+    task: partial_charges
+    output_port: chargemol.output_ddec6_populations
+  hirshfeld_populations:
+    task: partial_charges
+    output_port: cp2k.output_hirshfeld_populations
+  mulliken_populations:
+    task: partial_charges
+    output_port: cp2k.output_mulliken_populations


### PR DESCRIPTION
This PR includes the option of LDOS [https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/PRINT/PDOS/LDOS.html](url):

- Removes the option to resolve atoms via kinds and introduces `LDOS` and thus resolves atoms
- Adds option to group kinds in a list (e.g. equivalent sites) to calculate the `LDOS`
- Adds `LDOS` to the adsorption workflow for MOFs