### PR TITLE
Fix ``Structure.__deepcopy__`` function.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Version 0.5.0
 * The setter function of ``strct.Structure.cell`` now correctly removes the cell, scaled positions and periodic boundary conditions if set to ``None`` after initialization (`PR #192 <https://github.com/aim2dat/aim2dat/pull/192>`_).
 * ``strct.ext_manipulation.add_structure_coord`` resulted in a ``ValueError`` if no chemical bonds were detected in the guest structure (`PR #195 <https://github.com/aim2dat/aim2dat/pull/195>`_).
 * ``strct.ext_manipulation.add_structure_coord`` redundant rotations are skipped now (`PR #195 <https://github.com/aim2dat/aim2dat/pull/195>`_).
+* The ``strct.Structure.copy`` and ``strct.Structure.__deepcopy__`` functions did falsely not add ``site_attributes`` to the copied object (`PR #201 <https://github.com/aim2dat/aim2dat/pull/201>`_)
 
 **Breaking Changes:**
 

--- a/aim2dat/strct/structure.py
+++ b/aim2dat/strct/structure.py
@@ -207,17 +207,9 @@ class Structure(AnalysisMixin, ManipulationMixin, ImportExportMixin):
     def __deepcopy__(self, memo):
         """Create a deepcopy of the object."""
         copy = Structure(
-            elements=self.elements,
-            positions=self.positions,
-            cell=self.cell,
-            pbc=self.pbc,
             is_cartesian=True,
-            kinds=self.kinds,
-            attributes=self.attributes,
-            extras=self.extras,
-            function_args=self.function_args,
-            label=self.label,
             store_calculated_properties=self.store_calculated_properties,
+            **{key: getattr(self, key) for key in self.keys()},
         )
         memo[id(self)] = copy
         return copy

--- a/tests/strct/test_structure.py
+++ b/tests/strct/test_structure.py
@@ -151,6 +151,21 @@ def test_structure_validation():
     assert strct.pbc == (False, False, False)
 
 
+def test_copy(structure_comparison, nested_dict_comparison):
+    """Test deepcopy of structure."""
+    strct1 = Structure.from_str("water")
+    strct1.calc_coordination()
+    strct1.set_attribute("test_attr", 10)
+    strct1.set_site_attribute("test_site_attr", [0, 1, 2])
+    strct1.store_calculated_properties = False
+    strct2 = strct1.copy()
+    assert strct2.store_calculated_properties == strct1.store_calculated_properties
+    structure_comparison(strct1, strct2, compare_site_attrs=True)
+    nested_dict_comparison(strct1.attributes, strct2.attributes)
+    nested_dict_comparison(strct1.extras, strct2.extras)
+    nested_dict_comparison(strct1.function_args, strct2.function_args)
+
+
 def test_to_dict(structure_comparison):
     """Test to_dict function."""
     calc_keys = ["extras", "function_args"]


### PR DESCRIPTION
This PR fixes the ``Structure.__deepcopy__`` function by adding ``site_attributes`` to the list of properties to be copied.

Closes #198 