### PR TITLE
Bugfix for `chem_f.transform_str_to_dict` function.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,7 +19,8 @@ Version 0.5.0
 * The setter function of ``strct.Structure.cell`` now correctly removes the cell, scaled positions and periodic boundary conditions if set to ``None`` after initialization (`PR #192 <https://github.com/aim2dat/aim2dat/pull/192>`_).
 * ``strct.ext_manipulation.add_structure_coord`` resulted in a ``ValueError`` if no chemical bonds were detected in the guest structure (`PR #195 <https://github.com/aim2dat/aim2dat/pull/195>`_).
 * ``strct.ext_manipulation.add_structure_coord`` redundant rotations are skipped now (`PR #195 <https://github.com/aim2dat/aim2dat/pull/195>`_).
-* The ``strct.Structure.copy`` and ``strct.Structure.__deepcopy__`` functions did falsely not add ``site_attributes`` to the copied object (`PR #201 <https://github.com/aim2dat/aim2dat/pull/201>`_)
+* The ``strct.Structure.copy`` and ``strct.Structure.__deepcopy__`` functions did falsely not add ``site_attributes`` to the copied object (`PR #201 <https://github.com/aim2dat/aim2dat/pull/201>`_).
+* The ``chem_f.transform_str_to_dict`` function was throwing an error for some corner cases (`PR #204 <https://github.com/aim2dat/aim2dat/pull/204>`_).
 
 **Breaking Changes:**
 

--- a/aim2dat/chem_f/chem_formula.py
+++ b/aim2dat/chem_f/chem_formula.py
@@ -46,7 +46,7 @@ def transform_str_to_dict(formula_str):
         for idx, char in enumerate(formula_str):
             if char in ("(", "[", "{"):
                 stack.append(idx)
-            elif char in (")", "]", "}"):
+            elif idx > 0 and char in (")", "]", "}"):
                 group_st = stack.pop()
                 if len(stack) > 0:
                     continue

--- a/tests/test_chem_f.py
+++ b/tests/test_chem_f.py
@@ -42,6 +42,7 @@ def test_transformations(formula_dict, formula_str, formula_lat_str, formula_lis
         ("HOH", {"H": 2.0, "O": 1.0}),
         ("H.5(CO)CH3{OH[CH]4}3.5", {"C": 16.0, "O": 4.5, "H": 21.0}),
         ("(OH)2CH34", {"O": 2.0, "H": 36.0, "C": 1.0}),
+        ("(C38H34P2)MnBr4", {"Br": 4.0, "C": 38.0, "H": 34.0, "Mn": 1.0, "P": 2.0})
     ],
 )
 def test_str_transformations(formula_str, formula_dict):

--- a/tests/test_chem_f.py
+++ b/tests/test_chem_f.py
@@ -42,7 +42,7 @@ def test_transformations(formula_dict, formula_str, formula_lat_str, formula_lis
         ("HOH", {"H": 2.0, "O": 1.0}),
         ("H.5(CO)CH3{OH[CH]4}3.5", {"C": 16.0, "O": 4.5, "H": 21.0}),
         ("(OH)2CH34", {"O": 2.0, "H": 36.0, "C": 1.0}),
-        ("(C38H34P2)MnBr4", {"Br": 4.0, "C": 38.0, "H": 34.0, "Mn": 1.0, "P": 2.0})
+        ("(C38H34P2)MnBr4", {"Br": 4.0, "C": 38.0, "H": 34.0, "Mn": 1.0, "P": 2.0}),
     ],
 )
 def test_str_transformations(formula_str, formula_dict):


### PR DESCRIPTION
The corner case `"(C38H34P2)MnBr4"` would throw an error because the sub groups are not correctly detected.