### PR TITLE
Added finite-displacement phonon workflow for CP2K

### DIFF
--- a/aim2dat/aiida_workflows/cp2k/force_work_chain.py
+++ b/aim2dat/aiida_workflows/cp2k/force_work_chain.py
@@ -1,0 +1,66 @@
+"""
+AiiDA work chain for CP2K single-point force evaluations.
+
+This is the per-displacement force calculation used by the phonon workflow. It
+is a thin subclass of :class:`_BaseCoreWorkChain`, so every displacement
+inherits aim2dat's SCF-convergence recovery (atomic-guess fallback, mixing
+switches, open-shell escalation) -- the main reason to run finite-displacement
+phonons *inside* aim2dat rather than with a bare phonopy+CP2K driver.
+
+It differs from the property work chains only in the CP2K parameter block it
+injects: ``RUN_TYPE ENERGY_FORCE`` plus ``FORCE_EVAL/PRINT/FORCES ON`` so that
+the atomic forces appear in the (already-retrieved) CP2K output file, where
+phonopy's CP2K interface can read them.
+
+Proposed entry point (pyproject.toml)::
+
+    [project.entry-points."aiida.workflows"]
+    "aim2dat.cp2k.force_eval" =
+        "aim2dat.aiida_workflows.cp2k.force_work_chain:ForceWorkChain"
+"""
+
+# Third party library imports
+import aiida.orm as aiida_orm
+
+# Internal library imports
+from aim2dat.aiida_workflows.cp2k.base_core_work_chain import _BaseCoreWorkChain
+from aim2dat.aiida_workflows.cp2k.core_work_chain_handlers import _switch_to_atomic_scf_guess
+from aim2dat.utils.dict_tools import dict_set_parameter, dict_create_tree
+
+from aiida.engine import process_handler, ExitCode
+
+
+class ForceWorkChain(_BaseCoreWorkChain):
+    """
+    AiiDA work chain for a single-point CP2K energy+forces evaluation.
+    """
+
+    _keep_scf_method_fixed = False
+    _keep_smearing_fixed = False
+    _initial_scf_guess = "ATOMIC"
+
+    @classmethod
+    def define(cls, spec):
+        """Specify inputs and outputs."""
+        super().define(spec)
+        spec.input(
+            "adjust_scf_parameters",
+            valid_type=aiida_orm.Bool,
+            default=lambda: aiida_orm.Bool(False),
+            help="Restart with adjusted parameters if the SCF-cycles do not converge.",
+        )
+
+    def setup_wc_specific_inputs(self):
+        """Inject the ENERGY_FORCE run type and enable the forces print block."""
+        parameters = self.ctx.inputs.parameters.get_dict()
+        dict_set_parameter(parameters, ["GLOBAL", "RUN_TYPE"], "ENERGY_FORCE")
+        # Print the atomic forces into the CP2K output (read later by phonopy).
+        dict_create_tree(parameters, ["FORCE_EVAL", "PRINT", "FORCES"])
+        parameters["FORCE_EVAL"]["PRINT"]["FORCES"]["_"] = "ON"
+        self.ctx.inputs.parameters = aiida_orm.Dict(dict=parameters)
+        self.ctx.inputs.settings = aiida_orm.Dict(dict={"output_check_scf_conv": True})
+
+    @process_handler(priority=402, exit_codes=ExitCode(0))
+    def switch_to_atomic_scf_guess(self, calc):
+        """Switch to an atomic guess if the SCF-cycles do not converge."""
+        return self._execute_error_handler(calc, _switch_to_atomic_scf_guess)

--- a/aim2dat/aiida_workflows/cp2k/phonon_work_chain.py
+++ b/aim2dat/aiida_workflows/cp2k/phonon_work_chain.py
@@ -1,0 +1,220 @@
+"""
+AiiDA work chain for finite-displacement phonon calculations with CP2K.
+
+Unlike the single-calculation property work chains (band_structure, pdos, ...),
+a phonon calculation runs *N* force calculations -- one per symmetry-reduced
+displacement -- so this is a fan-out orchestrator (a plain ``WorkChain``, like
+``combined_work_chains``) rather than a ``_BaseCoreWorkChain`` subclass.
+
+Pipeline
+--------
+1. ``seekpath_structure_analysis``  -> primitive cell + q-point band path
+2. ``phonopy_generate_displacements`` -> N displaced supercells + setting info
+3. ``ForceWorkChain`` x N            -> CP2K ENERGY_FORCE per displacement
+4. ``parse_cp2k_forces``             -> stacked force sets
+5. ``phonopy_collect_phonons``       -> phonon band structure + DOS
+
+Proposed entry point (pyproject.toml)::
+
+    [project.entry-points."aiida.workflows"]
+    "aim2dat.cp2k.phonons" =
+        "aim2dat.aiida_workflows.cp2k.phonon_work_chain:PhononWorkChain"
+"""
+
+# Third party library imports
+import aiida.orm as aiida_orm
+from aiida.engine import WorkChain, ToContext
+from aiida.plugins import WorkflowFactory
+
+# Internal library imports
+from aim2dat.aiida_workflows.cp2k.work_chain_specs import structural_p_specs
+from aim2dat.aiida_workflows.utils import seekpath_structure_analysis
+from aim2dat.aiida_workflows.cp2k.phonopy_utils import (
+    phonopy_generate_displacements,
+    parse_cp2k_forces,
+    phonopy_collect_phonons,
+)
+
+ForceWorkChain = WorkflowFactory("aim2dat.cp2k.force_eval")
+
+
+def _seekpath_to_phonopy_path(path_parameters):
+    """Convert SeekPath ``path_parameters`` into a phonopy band path + labels.
+
+    NOTE for review/validation: the band path is defined in the reciprocal
+    coordinates of SeekPath's primitive cell, and phonopy is run on that same
+    primitive cell (``primitive_matrix='auto'``). For low-symmetry frameworks
+    the primitive-cell conventions should be cross-checked against the
+    script-pipeline ground truth (e.g. ZIF-8) -- this is the main correctness
+    point to validate.
+    """
+    point_coords = path_parameters["point_coords"]
+    band_path, band_labels = [], []
+    for segment in path_parameters["path"]:
+        band_path.append([point_coords[segment[0]], point_coords[segment[1]]])
+        band_labels.extend([segment[0], segment[1]])
+    return band_path, band_labels
+
+
+class PhononWorkChain(WorkChain):
+    """
+    AiiDA work chain to compute the phonon band structure and DOS via the
+    finite-displacement method with CP2K and phonopy.
+    """
+
+    @classmethod
+    def define(cls, spec):
+        """Specify inputs, outputs and the outline."""
+        super().define(spec)
+        spec = structural_p_specs(spec)
+
+        # --- phonopy settings ------------------------------------------------ #
+        spec.input(
+            "phonopy_p.supercell_matrix",
+            valid_type=aiida_orm.List,
+            help="Supercell matrix, e.g. [[2,0,0],[0,2,0],[0,0,2]].",
+        )
+        spec.input(
+            "phonopy_p.displacement",
+            valid_type=aiida_orm.Float,
+            default=lambda: aiida_orm.Float(0.01),
+            help="Displacement amplitude in Angstrom.",
+        )
+        spec.input(
+            "phonopy_p.symprec",
+            valid_type=aiida_orm.Float,
+            default=lambda: aiida_orm.Float(0.005),
+            help="Symmetry tolerance; should match the `eps_symmetry` used in the "
+            "upstream cell optimization.",
+        )
+        spec.input(
+            "phonopy_p.dos_mesh",
+            valid_type=aiida_orm.List,
+            default=lambda: aiida_orm.List(list=[20, 20, 20]),
+            help="q-point mesh for the phonon DOS.",
+        )
+        spec.input(
+            "phonopy_p.thermal_properties",
+            valid_type=aiida_orm.Bool,
+            default=lambda: aiida_orm.Bool(False),
+            help="Also compute thermal properties (free energy, Cv, entropy).",
+        )
+        # v2 TODO: non-analytical correction. Reserved now so adding it later
+        # does not change the input spec.
+        spec.input(
+            "phonopy_p.nac_parameters",
+            valid_type=aiida_orm.Dict,
+            required=False,
+            help="Reserved (v2): Born effective charges + dielectric tensor for the "
+            "non-analytical correction. Not used in v1.",
+        )
+
+        # --- band path (SeekPath) ------------------------------------------- #
+        spec.input(
+            "seekpath_parameters",
+            valid_type=aiida_orm.Dict,
+            default=lambda: aiida_orm.Dict(dict={"reference_distance": 0.015, "symprec": 0.005}),
+            help="Arguments passed to the SeekPath analysis for the band path.",
+        )
+
+        # --- per-displacement force calculation ----------------------------- #
+        # Exposes the CP2K code, numerical_p and SCF settings of ForceWorkChain;
+        # the structure is supplied per displacement.
+        spec.expose_inputs(
+            ForceWorkChain, namespace="force", exclude=("structural_p.structure",)
+        )
+
+        spec.outline(
+            cls.setup,
+            cls.run_forces,
+            cls.inspect_forces,
+            cls.collect_phonons,
+            cls.result,
+        )
+
+        spec.output("phonon_bands", valid_type=aiida_orm.Dict)
+        spec.output("phonon_dos", valid_type=aiida_orm.XyData)
+        spec.output("thermal_properties", valid_type=aiida_orm.Dict, required=False)
+        spec.output("phonon_setting_info", valid_type=aiida_orm.Dict)
+        spec.output_namespace(
+            "seekpath", required=False, dynamic=True,
+            help="Primitive structure / path from SeekPath."
+        )
+
+        spec.exit_code(
+            401,
+            "ERROR_FORCE_CALCULATION",
+            message="One or more displacement force calculations did not finish OK.",
+        )
+
+    def setup(self):
+        """Run SeekPath for the band path, then generate displaced supercells."""
+        seekpath = seekpath_structure_analysis(
+            self.inputs.structural_p.structure, self.inputs.seekpath_parameters
+        )
+        self.ctx.primitive_structure = seekpath["primitive_structure"]
+        self.ctx.path_parameters = seekpath["parameters"].get_dict()
+        self.out("seekpath.primitive_structure", seekpath["primitive_structure"])
+        self.out("seekpath.path_parameters", seekpath["parameters"])
+
+        gen_parameters = aiida_orm.Dict(
+            dict={
+                "supercell_matrix": self.inputs.phonopy_p.supercell_matrix.get_list(),
+                "displacement": self.inputs.phonopy_p.displacement.value,
+                "symprec": self.inputs.phonopy_p.symprec.value,
+            }
+        )
+        generated = phonopy_generate_displacements(self.ctx.primitive_structure, gen_parameters)
+        self.ctx.phonon_setting_info = generated.pop("phonon_setting_info")
+        self.ctx.supercells = dict(generated)  # supercell_XXXX -> StructureData
+        self.report(f"Generated {len(self.ctx.supercells)} displaced supercells.")
+
+    def run_forces(self):
+        """Fan out one ForceWorkChain per displaced supercell."""
+        for key in sorted(self.ctx.supercells):
+            inputs = self.exposed_inputs(ForceWorkChain, namespace="force")
+            inputs.structural_p.structure = self.ctx.supercells[key]
+            running = self.submit(ForceWorkChain, **inputs)
+            self.report(f"Launching ForceWorkChain <{running.pk}> for {key}.")
+            self.to_context(**{f"force_{key}": running})
+
+    def inspect_forces(self):
+        """Verify every force calculation finished and collect its output folder."""
+        self.ctx.retrieved = {}
+        for key in sorted(self.ctx.supercells):
+            wc = self.ctx[f"force_{key}"]
+            if not wc.is_finished_ok:
+                self.report(f"ForceWorkChain for {key} failed ({wc.exit_status}).")
+                return self.exit_codes.ERROR_FORCE_CALCULATION
+            # NOTE: verify the retrieved-folder output port name against the
+            # aim2dat.cp2k calcjob exposed outputs (assumed `cp2k.retrieved`).
+            self.ctx.retrieved[key] = wc.outputs.cp2k.retrieved
+
+    def collect_phonons(self):
+        """Parse forces and assemble the band structure + DOS."""
+        force_sets = parse_cp2k_forces(self.ctx.phonon_setting_info, **self.ctx.retrieved)[
+            "force_sets"
+        ]
+        band_path, band_labels = _seekpath_to_phonopy_path(self.ctx.path_parameters)
+        collect_parameters = aiida_orm.Dict(
+            dict={
+                "band_path": band_path,
+                "band_labels": band_labels,
+                "dos_mesh": self.inputs.phonopy_p.dos_mesh.get_list(),
+                "thermal_properties": self.inputs.phonopy_p.thermal_properties.value,
+            }
+        )
+        self.ctx.results = phonopy_collect_phonons(
+            self.ctx.primitive_structure,
+            self.ctx.phonon_setting_info,
+            force_sets,
+            collect_parameters,
+        )
+
+    def result(self):
+        """Expose the outputs."""
+        self.out("phonon_bands", self.ctx.results["band_structure"])
+        self.out("phonon_dos", self.ctx.results["total_dos"])
+        self.out("phonon_setting_info", self.ctx.phonon_setting_info)
+        if "thermal_properties" in self.ctx.results:
+            self.out("thermal_properties", self.ctx.results["thermal_properties"])

--- a/aim2dat/aiida_workflows/cp2k/phonopy_utils.py
+++ b/aim2dat/aiida_workflows/cp2k/phonopy_utils.py
@@ -1,0 +1,311 @@
+"""
+Calcfunctions wrapping phonopy for finite-displacement phonon workflows.
+
+This module provides the *forward* half of a finite-displacement phonon
+calculation as AiiDA calcfunctions, mirroring the idiom used by
+``seekpath_structure_analysis`` in ``aim2dat.aiida_workflows.utils``:
+
+* :func:`phonopy_generate_displacements` builds the supercell and the
+  symmetry-reduced set of displaced supercells from an optimized unit cell.
+* :func:`parse_cp2k_forces` reads the atomic forces from the retrieved CP2K
+  outputs (via phonopy's CP2K interface) and stacks them in displacement order.
+* :func:`phonopy_collect_phonons` assembles the force constants from those
+  forces and extracts the phonon band structure and DOS.
+
+The *backward* half (force constants -> band structure / DOS / thermal
+properties) is delegated to the existing extraction helpers in
+``aim2dat.ext_interfaces.phonopy`` so that a single phonopy code path is kept
+across the package.
+
+Note on force ingestion: the ``aim2dat.cp2k`` parser does not expose an atomic
+forces output port, and CP2K writes the atomic forces into its main output file
+(retrieved by default). :func:`parse_cp2k_forces` therefore reads them from the
+retrieved output via ``phonopy.interface.cp2k.parse_set_of_forces``, which
+handles the CP2K version detection, unit conversion, and drift correction.
+
+Proposed AiiDA workflow entry points (pyproject.toml)::
+
+    [project.entry-points."aiida.workflows"]
+    "aim2dat.phonopy.displacements" =
+        "aim2dat.aiida_workflows.cp2k.phonopy_utils:phonopy_generate_displacements"
+    "aim2dat.phonopy.parse_forces" =
+        "aim2dat.aiida_workflows.cp2k.phonopy_utils:parse_cp2k_forces"
+    "aim2dat.phonopy.collect" =
+        "aim2dat.aiida_workflows.cp2k.phonopy_utils:phonopy_collect_phonons"
+"""
+
+# Standard library imports
+import os
+import tempfile
+
+# Third party library imports
+import numpy as np
+import aiida.orm as aiida_orm
+from aiida.engine import calcfunction
+from aiida.plugins import DataFactory
+import phonopy
+from phonopy.structure.atoms import PhonopyAtoms
+from phonopy.interface.cp2k import parse_set_of_forces
+
+# Internal library imports -- reuse the existing extraction interface.
+from aim2dat.ext_interfaces.phonopy import (
+    _extract_band_structure,
+    _extract_total_dos,
+    _extract_projected_dos,
+    _extract_thermal_properties,
+)
+
+StructureData = DataFactory("core.structure")
+
+# Default name of the CP2K output file produced by the aim2dat.cp2k calcjob.
+# VERIFY against ``ForceWorkChain``'s ``metadata.options.output_filename``.
+_CP2K_OUTPUT_FILENAME = "aiida.out"
+
+
+# --------------------------------------------------------------------------- #
+# Converters
+# --------------------------------------------------------------------------- #
+def _structuredata_to_phonopy_atoms(structure):
+    """Convert an AiiDA ``StructureData`` node into a ``PhonopyAtoms`` object."""
+    ase_atoms = structure.get_ase()
+    return PhonopyAtoms(
+        symbols=ase_atoms.get_chemical_symbols(),
+        cell=ase_atoms.get_cell().array,
+        scaled_positions=ase_atoms.get_scaled_positions(),
+    )
+
+
+def _phonopy_atoms_to_structuredata(ph_atoms):
+    """Convert a ``PhonopyAtoms`` object into an AiiDA ``StructureData`` node."""
+    from ase import Atoms
+
+    ase_atoms = Atoms(
+        symbols=ph_atoms.symbols,
+        cell=ph_atoms.cell,
+        scaled_positions=ph_atoms.scaled_positions,
+        pbc=True,
+    )
+    return StructureData(ase=ase_atoms)
+
+
+def _build_phonopy(unitcell, settings):
+    """Instantiate a ``Phonopy`` object from a unit cell and settings dict."""
+    return phonopy.Phonopy(
+        unitcell,
+        supercell_matrix=settings["supercell_matrix"],
+        primitive_matrix=settings.get("primitive_matrix", "auto"),
+        symprec=settings.get("symprec", 1e-5),
+        calculator="cp2k",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Calcfunctions
+# --------------------------------------------------------------------------- #
+@calcfunction
+def phonopy_generate_displacements(structure, parameters):
+    """
+    Generate the symmetry-reduced set of displaced supercells.
+
+    Parameters
+    ----------
+    structure : aiida.orm.StructureData
+        The optimized unit cell. NOTE: to keep the displaced cell consistent
+        with the optimization, ``symprec`` should match the ``eps_symmetry``
+        used by the upstream ``cell_opt`` task (default 0.005 in the standard
+        protocols) rather than phonopy's looser default.
+    parameters : aiida.orm.Dict
+        Settings dictionary with the keys:
+            ``supercell_matrix`` (list[list[int]] | list[int]) - required,
+            ``primitive_matrix`` (str | list) - optional, default ``"auto"``,
+            ``symprec`` (float) - optional, default ``1e-5``,
+            ``displacement`` (float) - optional displacement amplitude in
+            Angstrom, default ``0.01``.
+
+    Returns
+    -------
+    dict
+        ``supercell_0000`` ... ``supercell_NNNN`` : aiida.orm.StructureData
+            One displaced supercell per displacement, fed to the per-displacement
+            force calculations (:class:`ForceWorkChain`, RUN_TYPE ENERGY_FORCE).
+        ``phonon_setting_info`` : aiida.orm.Dict
+            Displacement dataset + supercell settings, carried forward to
+            :func:`parse_cp2k_forces` and :func:`phonopy_collect_phonons`.
+    """
+    settings = parameters.get_dict()
+    unitcell = _structuredata_to_phonopy_atoms(structure)
+    phonon = _build_phonopy(unitcell, settings)
+    phonon.generate_displacements(distance=settings.get("displacement", 0.01))
+
+    supercells = phonon.supercells_with_displacements
+
+    outputs = {}
+    for i, supercell in enumerate(supercells):
+        outputs[f"supercell_{i:04d}"] = _phonopy_atoms_to_structuredata(supercell)
+
+    outputs["phonon_setting_info"] = aiida_orm.Dict(
+        dict={
+            "supercell_matrix": settings["supercell_matrix"],
+            "primitive_matrix": settings.get("primitive_matrix", "auto"),
+            "symprec": settings.get("symprec", 1e-5),
+            "displacement": settings.get("displacement", 0.01),
+            "displacement_dataset": phonon.dataset,
+            "number_of_displacements": len(supercells),
+            "supercell_n_atoms": len(supercells[0]),
+        }
+    )
+    return outputs
+
+
+@calcfunction
+def parse_cp2k_forces(phonon_setting_info, **retrieved):
+    """
+    Read CP2K atomic forces from the retrieved outputs, in displacement order.
+
+    Reuses ``phonopy.interface.cp2k.parse_set_of_forces`` so CP2K version
+    detection, unit conversion, and drift correction match the rest of phonopy.
+
+    Parameters
+    ----------
+    phonon_setting_info : aiida.orm.Dict
+        Output of :func:`phonopy_generate_displacements`.
+    **retrieved : aiida.orm.FolderData
+        One retrieved folder per displacement, each containing the CP2K output
+        file. Keys are sorted to recover the displacement order, so pass them as
+        ``supercell_0000=<retrieved>, supercell_0001=<retrieved>, ...``.
+
+    Returns
+    -------
+    dict
+        ``force_sets`` : aiida.orm.ArrayData
+            Array ``force_sets`` of shape ``(n_displacements, n_atoms, 3)``.
+    """
+    n_atoms = phonon_setting_info.get_dict()["supercell_n_atoms"]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        filenames = []
+        for i, key in enumerate(sorted(retrieved)):
+            folder = retrieved[key]
+            content = folder.get_object_content(_CP2K_OUTPUT_FILENAME)
+            path = os.path.join(tmp, f"force_{i:04d}.out")
+            with open(path, "w") as handle:
+                handle.write(content)
+            filenames.append(path)
+        force_sets = parse_set_of_forces(n_atoms, filenames, verbose=False)
+
+    array = aiida_orm.ArrayData()
+    array.set_array("force_sets", np.array(force_sets))
+    return {"force_sets": array}
+
+
+@calcfunction
+def phonopy_collect_phonons(structure, phonon_setting_info, force_sets, parameters):
+    """
+    Assemble force constants and extract the phonon band structure and DOS.
+
+    Parameters
+    ----------
+    structure : aiida.orm.StructureData
+        The same optimized unit cell passed to
+        :func:`phonopy_generate_displacements`.
+    phonon_setting_info : aiida.orm.Dict
+        The ``phonon_setting_info`` output of
+        :func:`phonopy_generate_displacements`.
+    force_sets : aiida.orm.ArrayData
+        Array ``force_sets`` of shape ``(n_displacements, n_atoms, 3)``, as
+        produced by :func:`parse_cp2k_forces`.
+    parameters : aiida.orm.Dict
+        Post-processing settings:
+            ``band_path`` (list) - q-point path segments (from SeekPath),
+            ``band_labels`` (list) - high-symmetry point labels,
+            ``band_npoints`` (int) - points per segment, default ``101``,
+            ``with_eigenvectors`` (bool) - default ``False``,
+            ``dos_mesh`` (list[int]) - q-mesh for the DOS, default ``[20,20,20]``,
+            ``thermal_properties`` (bool) - default ``False``,
+            ``t_min`` / ``t_max`` / ``t_step`` (float) - thermal range.
+
+    Returns
+    -------
+    dict
+        ``band_structure`` : aiida.orm.Dict - phonopy band-structure dict.
+        ``total_dos`` : aiida.orm.XyData - frequency vs. total phonon DOS.
+        ``thermal_properties`` : aiida.orm.Dict - present only if requested.
+    """
+    settings = phonon_setting_info.get_dict()
+    p_dict = parameters.get_dict()
+
+    unitcell = _structuredata_to_phonopy_atoms(structure)
+    phonon = _build_phonopy(unitcell, settings)
+    phonon.dataset = settings["displacement_dataset"]
+    phonon.forces = force_sets.get_array("force_sets")
+    phonon.produce_force_constants()
+    phonon.symmetrize_force_constants()
+
+    # --- v2 TODO: non-analytical correction (NAC) -------------------------- #
+    # For polar frameworks, set the Born effective charges + dielectric tensor
+    # here (computed by CP2K) to capture LO-TO splitting near Gamma:
+    #     phonon.nac_params = {"born": ..., "dielectric": ..., "factor": ...}
+    # The input spec deliberately reserves a `nac_parameters` slot so adding
+    # this in v2 does not break the API.
+    # ----------------------------------------------------------------------- #
+
+    outputs = {}
+    # Reuse aim2dat's existing extraction interface, which loads from a
+    # phonopy_params.yaml. Save the force constants to a temporary file and
+    # point `load_parameters` at it.
+    #
+    # NOTE for review: a small refactor of `ext_interfaces.phonopy._extract_*`
+    # to optionally accept a pre-built `Phonopy` object would avoid this file
+    # round-trip. Kept file-based here to leave the existing interface
+    # untouched for the first PR.
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = os.path.join(tmp, "phonopy_params.yaml")
+        phonon.save(filename=yaml_path, settings={"force_constants": True})
+        load_parameters = {"phonopy_yaml": yaml_path, "calculator": "cp2k"}
+
+        # Band structure
+        band_dict, _primitive_cell = _extract_band_structure(
+            load_parameters,
+            p_dict["band_path"],
+            p_dict["band_labels"],
+            p_dict.get("band_npoints", 101),
+            p_dict.get("with_eigenvectors", False),
+        )
+        outputs["band_structure"] = aiida_orm.Dict(dict=_jsonify(band_dict))
+
+        # Total DOS -> XyData
+        dos_dict = _extract_total_dos(load_parameters, p_dict.get("dos_mesh", [20, 20, 20]))
+        dos = aiida_orm.XyData()
+        dos.set_x(np.array(dos_dict["frequency_points"]), "frequency", "THz")
+        dos.set_y(np.array(dos_dict["total_dos"]), "total_dos", "states/THz")
+        outputs["total_dos"] = dos
+
+        # Optional thermal properties
+        if p_dict.get("thermal_properties", False):
+            thermal = _extract_thermal_properties(
+                load_parameters,
+                p_dict.get("dos_mesh", [20, 20, 20]),
+                p_dict.get("t_min", 0.0),
+                p_dict.get("t_max", 1000.0),
+                p_dict.get("t_step", 10.0),
+            )
+            outputs["thermal_properties"] = aiida_orm.Dict(dict=_jsonify(thermal))
+
+    return outputs
+
+
+def _jsonify(obj):
+    """Recursively convert numpy arrays/scalars to JSON-serializable types.
+
+    phonopy's result dicts contain numpy arrays which AiiDA's ``Dict`` cannot
+    store directly.
+    """
+    if isinstance(obj, dict):
+        return {k: _jsonify(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_jsonify(v) for v in obj]
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.floating, np.integer)):
+        return obj.item()
+    return obj

--- a/aim2dat/aiida_workflows/protocols/cp2k-crystal-phonons_v1.0.yaml
+++ b/aim2dat/aiida_workflows/protocols/cp2k-crystal-phonons_v1.0.yaml
@@ -1,0 +1,381 @@
+%YAML 1.2
+---
+title: cp2k-crystal-phonons
+version: '1.0'
+description: >
+  Full phonon pipeline for crystalline semiconductors/insulators:
+  (1) find_scf_parameters — SCF convergence search with DZVP basis;
+  (2) unit_cell_preopt    — fast pre-relaxation with DZVP, loose thresholds;
+  (3) unit_cell_opt       — production cell optimization with TZV2P, tight thresholds;
+  (4) phonons             — finite-displacement phonon band structure + DOS with TZV2P.
+  Designed and tested on Si (Fd-3m); suitable for other semiconductors / band-gap insulators.
+dependencies:
+- [aiida-core, '1.6', Null]
+- [seekpath, '2.0', Null]
+parent_node_type: structure
+parent_node_input:
+  find_scf_parameters: structural_p.structure
+  unit_cell_preopt: structural_p.structure
+tasks:
+  find_scf_parameters:
+    process: aim2dat.cp2k.find_scf_p
+    blacklist_inputs:
+    - custom_scf_method
+  unit_cell_preopt:
+    process: aim2dat.cp2k.cell_opt
+    blacklist_inputs:
+    - custom_scf_method
+    - optimization_p.keep_angles
+    - optimization_p.keep_symmetry
+    dependencies:
+      find_scf_parameters:
+      - [scf_parameters, structural_p.scf_parameters]
+  unit_cell_opt:
+    process: aim2dat.cp2k.cell_opt
+    blacklist_inputs:
+    - custom_scf_method
+    - optimization_p.keep_angles
+    - optimization_p.keep_symmetry
+    dependencies:
+      unit_cell_preopt:
+      - [cp2k.output_structure, structural_p.structure]
+      - [scf_parameters, structural_p.scf_parameters]
+  phonons:
+    process: aim2dat.cp2k.phonons
+    dependencies:
+      unit_cell_opt:
+      - [cp2k.output_structure, structural_p.structure]
+      - [scf_parameters, force.structural_p.scf_parameters]
+
+general_input:
+  # ── CP2K parameters shared by all cell-opt tasks ──────────────────────────
+  cp2k.parameters:
+    value:
+      GLOBAL:
+        PRINT_LEVEL: MEDIUM
+        PREFERRED_DIAG_LIBRARY: SCALAPACK
+        EXTENDED_FFT_LENGTHS: true
+      FORCE_EVAL:
+        METHOD: Quickstep
+        STRESS_TENSOR: ANALYTICAL
+        DFT:
+          MGRID: {}
+          POISSON: {PERIODIC: XYZ, POISSON_SOLVER: PERIODIC}
+          BASIS_SET_FILE_NAME: [BASIS_MOLOPT_UZH, BASIS_MOLOPT]
+          POTENTIAL_FILE_NAME: GTH_POTENTIALS
+          QS: {EXTRAPOLATION: USE_GUESS, EPS_DEFAULT: 1.0e-14}
+          SCF: {EPS_SCF: 5.0e-7}
+          KPOINTS:
+            EPS_GEO: 1.0e-8
+            FULL_GRID: false
+            SYMMETRY: false
+          XC: {}
+        SUBSYS:
+          CELL: {PERIODIC: XYZ}
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+
+  # CP2K parameters for the per-displacement force evaluations (no KPOINTS block;
+  # force supercells are large enough that Gamma-only is appropriate).
+  # Moved to user_input so EPS_SCF / MAX_SCF can be overridden from a notebook
+  # without editing this file.  See the force.cp2k.parameters entry in user_input.
+
+  # ── k-point density (Å⁻¹) ─────────────────────────────────────────────────
+  numerical_p.kpoints_ref_dist:
+    value: 0.15
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_opt]
+  numerical_p.kpoints_ref_dist->unit_cell_preopt:
+    value: 0.25
+    aiida_node: true
+    compare: false
+
+  # ── SCF solver settings ───────────────────────────────────────────────────
+  scf_method:
+    value: density_mixing
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.scf_method:
+    value: density_mixing
+    aiida_node: true
+    tasks: [phonons]
+
+  factor_unocc_states:
+    value: 0.75
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.factor_unocc_states:
+    value: 0.75
+    aiida_node: true
+    tasks: [phonons]
+
+  enable_roks:
+    value: false
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.enable_roks:
+    value: false
+    aiida_node: true
+    tasks: [phonons]
+
+  always_add_unocc_states:
+    value: true
+    aiida_node: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+
+  adjust_scf_parameters:
+    value: true
+    aiida_node: true
+    tasks: [unit_cell_preopt, unit_cell_opt]
+
+  max_iterations:
+    value: 100
+    aiida_node: true
+    compare: false
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.max_iterations:
+    value: 100
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Geometry optimisation thresholds ──────────────────────────────────────
+  optimization_p.keep_space_group:
+    value: true
+    aiida_node: true
+    tasks: [unit_cell_preopt, unit_cell_opt]
+  optimization_p.eps_symmetry:
+    value: 0.005
+    aiida_node: true
+    tasks: [unit_cell_preopt, unit_cell_opt]
+  optimization_p.ref_cell_scaling_factor:
+    value: 1.5
+    aiida_node: true
+    tasks: [unit_cell_preopt, unit_cell_opt]
+
+  # Preopt — loose pressure threshold for speed
+  optimization_p.pressure_tolerance->unit_cell_preopt:
+    value: 200.0
+    aiida_node: true
+    compare: false
+
+  # Final opt — tight pressure threshold so cell volume is well-converged for phonons
+  optimization_p.pressure_tolerance->unit_cell_opt:
+    value: 100.0
+    aiida_node: true
+
+  # ── Phonopy defaults ──────────────────────────────────────────────────────
+  phonopy_p.displacement:
+    value: 0.01
+    aiida_node: true
+    tasks: [phonons]
+  phonopy_p.symprec:
+    value: 0.005
+    aiida_node: true
+    tasks: [phonons]
+  phonopy_p.dos_mesh:
+    value: [20, 20, 20]
+    aiida_node: true
+    tasks: [phonons]
+  seekpath_parameters:
+    value: {reference_distance: 0.015, symprec: 0.005}
+    aiida_node: true
+    tasks: [phonons]
+
+user_input:
+  # ── Extended-system flag (false for semiconductors / insulators) ──────────
+  scf_extended_system:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.scf_extended_system:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # CP2K parameters for per-displacement force evaluations.
+  # Kept in user_input (optional, with a default) so EPS_SCF and MAX_SCF can
+  # be tuned from a notebook via set_user_input("force.cp2k.parameters", ...).
+  # Default: EPS_SCF=1e-8 / MAX_SCF=200 — tighter than geometry steps because
+  # SCF noise at 5e-7 caused imaginary modes at zone boundaries (X, L) when
+  # force constants are reconstructed from a single displaced supercell.
+  force.cp2k.parameters:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [phonons]
+    value:
+      GLOBAL:
+        PRINT_LEVEL: MEDIUM
+        PREFERRED_DIAG_LIBRARY: SCALAPACK
+        EXTENDED_FFT_LENGTHS: true
+      FORCE_EVAL:
+        METHOD: Quickstep
+        DFT:
+          MGRID: {}
+          POISSON: {PERIODIC: XYZ, POISSON_SOLVER: PERIODIC}
+          BASIS_SET_FILE_NAME: [BASIS_MOLOPT_UZH, BASIS_MOLOPT]
+          POTENTIAL_FILE_NAME: GTH_POTENTIALS
+          QS: {EXTRAPOLATION: USE_GUESS, EPS_DEFAULT: 1.0e-14}
+          SCF: {EPS_SCF: 1.0e-8, MAX_SCF: 200}
+          XC: {}
+        SUBSYS:
+          CELL: {PERIODIC: XYZ}
+
+  # ── XC functional ─────────────────────────────────────────────────────────
+  numerical_p.xc_functional:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.numerical_p.xc_functional:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Basis sets — DZVP for find_scf / preopt, TZV2P for opt / phonons ──────
+  numerical_p.basis_sets:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters, unit_cell_opt]
+  numerical_p.basis_sets->unit_cell_preopt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  force.numerical_p.basis_sets:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Grid cutoffs — lower for find_scf/preopt, higher for opt/phonons ──────
+  numerical_p.cutoff_values:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: true
+    tasks: [find_scf_parameters]
+  numerical_p.cutoff_values->unit_cell_preopt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  numerical_p.cutoff_values->unit_cell_opt:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+  force.numerical_p.cutoff_values:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Compute code & scheduler metadata ─────────────────────────────────────
+  cp2k.code:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    compare: false
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  cp2k.metadata:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.cp2k.code:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+  force.cp2k.metadata:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: false
+    unstored: true
+    optional: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Geometry optimisation force thresholds (user-overridable with defaults) ─
+  # Preopt uses a loose threshold for speed; opt uses 1.9e-5 Ha/Bohr so that
+  # residual forces in the relaxed cell are small enough for accurate phonons.
+  optimization_p.max_force->unit_cell_preopt:
+    validation: aim2dat.cp2k.cell_opt
+    aiida_node: true
+    optional: true
+    compare: false
+    value: 0.005
+  optimization_p.max_force->unit_cell_opt:
+    validation: aim2dat.cp2k.cell_opt
+    aiida_node: true
+    optional: true
+    compare: false
+    value: 1.9e-5
+
+  # ── Thermal properties (free energy, Cv, entropy vs. T) ─────────────────────
+  phonopy_p.thermal_properties:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [phonons]
+    value: false
+
+  # ── Supercell matrix — must be set per structure ──────────────────────────
+  phonopy_p.supercell_matrix:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    compare: false
+    tasks: [phonons]
+
+  # ── Optional: clean scratch directories after each step ───────────────────
+  clean_workdir:
+    validation: aim2dat.cp2k.find_scf_p
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [find_scf_parameters, unit_cell_preopt, unit_cell_opt]
+  force.clean_workdir:
+    validation: aim2dat.cp2k.phonons
+    aiida_node: true
+    optional: true
+    compare: false
+    tasks: [phonons]
+
+results:
+  scf_method_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [method_level]
+  scf_parameter_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [parameter_level]
+  scf_smearing_level:
+    task: find_scf_parameters
+    output_port: scf_parameters
+    retrieve_value: [smearing_level]
+  optimized_structure:
+    task: unit_cell_opt
+    output_port: cp2k.output_structure
+  total_energy:
+    task: unit_cell_opt
+    output_port: cp2k.output_parameters
+    retrieve_value: [energy]
+    unit: Hartree
+  space_group:
+    task: unit_cell_opt
+    output_port: cp2k.output_parameters
+    retrieve_value: [spgr_info, sg_number]
+  phonon_bands:
+    task: phonons
+    output_port: phonon_bands
+  phonon_dos:
+    task: phonons
+    output_port: phonon_dos
+  phonon_setting_info:
+    task: phonons
+    output_port: phonon_setting_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ authors = [
   {name = "Holger-Dietrich Saßnick", email = "holger-dietrich.sassnick@uni-oldenburg.de"},
   {name = "Timo Reents", email = "timo.reents@uni-oldenburg.de"},
   {name = "Joshua Edzards", email = "joshua.edzards@uni-oldenburg.de"},
+  {name = "Maddox Turner", email = "mdturne9@asu.edu"},
 ]
 maintainers = [
   {name = "Holger-Dietrich Saßnick", email = "holger-dietrich.sassnick@uni-oldenburg.de"}
@@ -159,6 +160,11 @@ pre-commit = [
 "aim2dat.cp2k.combined.surface_opt" = "aim2dat.aiida_workflows.cp2k.combined_work_chains:SurfaceOptWorkChain"
 "aim2dat.cp2k.combined.electronic_properties" = "aim2dat.aiida_workflows.cp2k.combined_work_chains:ElectronicPropertiesWorkChain"
 "aim2dat.cp2k.interaction_energy" = "aim2dat.aiida_workflows.cp2k.interaction_energy_work_chain:InteractionEnergyWorkChain"
+"aim2dat.cp2k.force_eval" = "aim2dat.aiida_workflows.cp2k.force_work_chain:ForceWorkChain"
+"aim2dat.cp2k.phonons"   = "aim2dat.aiida_workflows.cp2k.phonon_work_chain:PhononWorkChain"
+"aim2dat.phonopy.displacements" = "aim2dat.aiida_workflows.cp2k.phonopy_utils:phonopy_generate_displacements"
+"aim2dat.phonopy.parse_forces"  = "aim2dat.aiida_workflows.cp2k.phonopy_utils:parse_cp2k_forces"
+"aim2dat.phonopy.collect"       = "aim2dat.aiida_workflows.cp2k.phonopy_utils:phonopy_collect_phonons"
 
 [tool.setuptools.packages.find]
 include = ["aim2dat*"]

--- a/tests/aiida_workflows/test_phonopy_utils.py
+++ b/tests/aiida_workflows/test_phonopy_utils.py
@@ -1,0 +1,254 @@
+"""Tests for the phonopy_utils calcfunctions (finite-displacement phonon pipeline)."""
+
+# Standard library imports
+import io
+import os
+
+# Third party library imports
+import numpy as np
+import pytest
+import aiida.orm as aiida_orm
+from aiida.plugins import DataFactory
+
+# Internal library imports
+from aim2dat.io import read_yaml_file
+from aim2dat.aiida_workflows.cp2k.phonopy_utils import (
+    phonopy_generate_displacements,
+    parse_cp2k_forces,
+    phonopy_collect_phonons,
+)
+
+TEST_SYSTEMS_PATH = os.path.dirname(__file__) + "/cp2k/test_systems/"
+
+StructureData = DataFactory("core.structure")
+
+# Minimal Γ→X band path for Si (FCC reciprocal space)
+_SI_BAND_PATH = [[[0.0, 0.0, 0.0], [0.5, 0.0, 0.5]]]
+_SI_BAND_LABELS = ["GAMMA", "X"]
+
+_SI_CRYSTAL_DICT = dict(
+    read_yaml_file(TEST_SYSTEMS_PATH + "Si_crystal.yaml")
+)["structure"]
+
+
+def _make_cp2k_force_content(n_atoms, forces):
+    """Return a minimal CP2K 2024-format force-output string for ``n_atoms`` atoms."""
+    lines = [
+        " ATOMIC FORCES in [a.u.]",
+        "",
+        " # Atom   Kind   Element          X              Y              Z",
+    ]
+    for idx, (fx, fy, fz) in enumerate(forces):
+        lines.append(
+            f"      {idx + 1}      1      Si    {fx:14.8f}   {fy:14.8f}   {fz:14.8f}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _si_folder_with_forces(forces):
+    """Wrap ``forces`` (shape n_atoms×3) in a FolderData named 'aiida.out'."""
+    content = _make_cp2k_force_content(len(forces), forces)
+    folder = aiida_orm.FolderData()
+    folder.put_object_from_filelike(io.StringIO(content), "aiida.out")
+    return folder
+
+
+# --------------------------------------------------------------------------- #
+# Test 1 — phonopy_generate_displacements
+# --------------------------------------------------------------------------- #
+@pytest.mark.aiida
+def test_phonopy_generate_displacements(aiida_create_structuredata):
+    """Displaced supercells and setting info are generated correctly for Si."""
+    si = aiida_create_structuredata(_SI_CRYSTAL_DICT)  # 2-atom FCC primitive cell
+
+    parameters = aiida_orm.Dict(
+        dict={
+            "supercell_matrix": [[2, 0, 0], [0, 2, 0], [0, 0, 2]],
+            "symprec": 1e-5,
+            "displacement": 0.01,
+        }
+    )
+
+    outputs = phonopy_generate_displacements(si, parameters)
+
+    info = outputs["phonon_setting_info"].get_dict()
+
+    # Check Si has one symmetry-reduced displacement in a 2×2×2 supercell
+    assert info["number_of_displacements"] == 1
+    assert "supercell_0000" in outputs
+    assert "supercell_0001" not in outputs
+
+    supercell = outputs["supercell_0000"]
+    assert isinstance(supercell, StructureData)
+    assert len(supercell.get_ase()) == 16  # 2 atoms × 2×2×2
+
+    # Check setting info carries all keys forward to parse/collect steps
+    assert info["supercell_n_atoms"] == 16
+    assert info["supercell_matrix"] == [[2, 0, 0], [0, 2, 0], [0, 0, 2]]
+    assert info["displacement"] == 0.01
+    assert "displacement_dataset" in info
+
+
+# --------------------------------------------------------------------------- #
+# Test 2 — parse_cp2k_forces
+# --------------------------------------------------------------------------- #
+@pytest.mark.aiida
+def test_parse_cp2k_forces(aiida_create_structuredata):
+    """Forces are read from CP2K output files and returned as an ArrayData."""
+    si = aiida_create_structuredata(_SI_CRYSTAL_DICT)
+
+    parameters = aiida_orm.Dict(
+        dict={
+            "supercell_matrix": [[2, 0, 0], [0, 2, 0], [0, 0, 2]],
+            "symprec": 1e-5,
+            "displacement": 0.01,
+        }
+    )
+    disp_outputs = phonopy_generate_displacements(si, parameters)
+    phonon_setting_info = disp_outputs["phonon_setting_info"]
+
+    n_atoms = 16
+    # Synthetic restoring force on displaced atom; Newton's-3rd reaction on neighbours
+    disp = phonon_setting_info.get_dict()["displacement_dataset"]["first_atoms"][0][
+        "displacement"
+    ]
+    k = 5.0  # arbitrary spring constant [a.u.]
+    forces = np.zeros((n_atoms, 3))
+    forces[0] = [-k * d for d in disp]
+    forces[1] = [k * d / 2 for d in disp]
+    forces[2] = [k * d / 2 for d in disp]
+
+    folder = _si_folder_with_forces(forces)
+    outputs = parse_cp2k_forces(phonon_setting_info, supercell_0000=folder)
+
+    #Check force sets output correct shape and finite 
+    force_sets = outputs["force_sets"].get_array("force_sets")
+    assert force_sets.shape == (1, n_atoms, 3)
+    assert np.all(np.isfinite(force_sets))
+
+
+# --------------------------------------------------------------------------- #
+# Test 3 — phonopy_collect_phonons  (band structure + DOS, no thermal)
+# --------------------------------------------------------------------------- #
+@pytest.mark.aiida
+def test_phonopy_collect_phonons_bands_dos(aiida_create_structuredata):
+    """Band structure and total DOS are assembled from force constants."""
+    si = aiida_create_structuredata(_SI_CRYSTAL_DICT)
+
+    parameters = aiida_orm.Dict(
+        dict={
+            "supercell_matrix": [[2, 0, 0], [0, 2, 0], [0, 0, 2]],
+            "symprec": 1e-5,
+            "displacement": 0.01,
+        }
+    )
+    disp_outputs = phonopy_generate_displacements(si, parameters)
+    phonon_setting_info = disp_outputs["phonon_setting_info"]
+
+    disp = phonon_setting_info.get_dict()["displacement_dataset"]["first_atoms"][0][
+        "displacement"
+    ]
+    k = 5.0
+    forces = np.zeros((16, 3))
+    forces[0] = [-k * d for d in disp]
+    forces[1] = [k * d / 2 for d in disp]
+    forces[2] = [k * d / 2 for d in disp]
+
+    force_outputs = parse_cp2k_forces(
+        phonon_setting_info, supercell_0000=_si_folder_with_forces(forces)
+    )
+
+    collect_params = aiida_orm.Dict(
+        dict={
+            "band_path": _SI_BAND_PATH,
+            "band_labels": _SI_BAND_LABELS,
+            "band_npoints": 11,
+            "dos_mesh": [4, 4, 4],
+            "thermal_properties": False,
+        }
+    )
+
+    outputs = phonopy_collect_phonons(
+        si, phonon_setting_info, force_outputs["force_sets"], collect_params
+    )
+
+    #Check outputs for correct values
+    assert "band_structure" in outputs
+    assert "total_dos" in outputs
+    assert "thermal_properties" not in outputs
+
+    #Confirm band structure outputs are correct
+    bs = outputs["band_structure"].get_dict()
+    assert "distances" in bs
+    assert "frequencies" in bs
+    assert len(bs["distances"]) == 1          # one path segment
+    assert len(bs["distances"][0]) == 11      # band_npoints
+    assert len(bs["frequencies"][0][0]) == 6  # 2 atoms × 3 modes
+
+    #Confirm DOS units and shape correct
+    x_label, x_vals, x_unit = outputs["total_dos"].get_x()
+    assert x_unit == "THz"
+    assert len(x_vals) > 0
+    y_vals = outputs["total_dos"].get_y()[0][1]
+    assert len(y_vals) == len(x_vals)
+
+
+# --------------------------------------------------------------------------- #
+# Test 4 — phonopy_collect_phonons  (with thermal properties)
+# --------------------------------------------------------------------------- #
+@pytest.mark.aiida
+def test_phonopy_collect_phonons_thermal(aiida_create_structuredata):
+    """Thermal properties dict is included when thermal_properties=True."""
+    si = aiida_create_structuredata(_SI_CRYSTAL_DICT)
+
+    parameters = aiida_orm.Dict(
+        dict={
+            "supercell_matrix": [[2, 0, 0], [0, 2, 0], [0, 0, 2]],
+            "symprec": 1e-5,
+            "displacement": 0.01,
+        }
+    )
+    disp_outputs = phonopy_generate_displacements(si, parameters)
+    phonon_setting_info = disp_outputs["phonon_setting_info"]
+
+    disp = phonon_setting_info.get_dict()["displacement_dataset"]["first_atoms"][0][
+        "displacement"
+    ]
+    k = 5.0
+    forces = np.zeros((16, 3))
+    forces[0] = [-k * d for d in disp]
+    forces[1] = [k * d / 2 for d in disp]
+    forces[2] = [k * d / 2 for d in disp]
+
+    force_outputs = parse_cp2k_forces(
+        phonon_setting_info, supercell_0000=_si_folder_with_forces(forces)
+    )
+
+    collect_params = aiida_orm.Dict(
+        dict={
+            "band_path": _SI_BAND_PATH,
+            "band_labels": _SI_BAND_LABELS,
+            "band_npoints": 11,
+            "dos_mesh": [4, 4, 4],
+            "thermal_properties": True,
+            "t_min": 0.0,
+            "t_max": 100.0,
+            "t_step": 50.0,
+        }
+    )
+
+    outputs = phonopy_collect_phonons(
+        si, phonon_setting_info, force_outputs["force_sets"], collect_params
+    )
+
+    #Confirm thermal properties in outputs
+    assert "thermal_properties" in outputs
+
+    #Confirm all thermal props are there 
+    tp = outputs["thermal_properties"].get_dict()
+    assert "temperatures" in tp
+    assert "free_energy" in tp
+    assert "entropy" in tp
+    assert "heat_capacity" in tp
+    # t_min=0, t_max=100, t_step=50 → temperatures [0, 50, 100]
+    assert len(tp["temperatures"]) == 3


### PR DESCRIPTION
## Summary

Adds a complete finite-displacement phonon band structure + DOS pipeline
for CP2K, driven by phonopy, and integrated with aim2dat's existing
WorkflowBuilder protocol system.

## New workflow

`aim2dat.cp2k.phonons` (PhononWorkChain) orchestrates:

1. SeekPath → primitive cell + band path
2. `phonopy_generate_displacements` → N displaced supercells
3. `ForceWorkChain` × N → CP2K ENERGY_FORCE per displacement
   (inherits _BaseCoreWorkChain SCF auto-recovery)
4. `parse_cp2k_forces` → stacked force sets via phonopy's CP2K interface
5. `phonopy_collect_phonons` → band structure + DOS

Outputs: `phonon_bands` (Dict), `phonon_dos` (XyData),
`phonon_setting_info` (Dict), optional `thermal_properties` (Dict).

## Design decisions

- **phonopy runs locally** (calcfunctions, not on cluster) — only DFT
  force calcs go to the cluster, preserving N-way parallelism
- **Reuses `ext_interfaces.phonopy._extract_*`** for post-processing —
  single phonopy code path in the package
- **`symprec` defaults to 0.005** to match `eps_symmetry` in cell_opt,
  keeping displacement symmetry consistent with the optimization
- **Non-Analytical Corrections(NAC) reserved** as `phonopy_p.nac_parameters` input (v2 TODO) —
  API designed so adding LO-TO correction doesn't break existing inputs
- **Protocol included** (`cp2k-crystal-phonons_v1.0.yaml`): full
  find_scf → preopt (DZVP) → opt (TZV2P) → phonons pipeline with
  tighter EPS_SCF=1e-8 for force evals to suppress SCF-noise imaginary modes

## Validation


- Si PBE/TZV2P: full pipeline finished [0] on GWDG, band structure + DOS
  consistent with Materials Project reference (✓)
- NaCl PBE/TZV2P: full pipeline finished [0], acoustic modes = 0 at Γ, but Imaginary freqs at boundaries and no LO-TO splitting observed - v2 fix (×)

## Notes for reviewers

- Forces are read from `aiida.out` (default retrieved file) via
  `phonopy.interface.cp2k.parse_set_of_forces` — please verify the
  output filename assumption matches all CP2K calcjob configurations
- `ext_interfaces.phonopy._extract_*` use deprecated phonopy 4.x API
  (`get_band_structure_dict` / `get_total_dos_dict`) — flagging for
  future update independently of this PR
- Tests use stand-in forces (no CP2K needed)